### PR TITLE
Fix projections GUI on wayland

### DIFF
--- a/bin/projections
+++ b/bin/projections
@@ -10,6 +10,12 @@ then
   fi 
 fi
 
+IS_WAYLAND=`env | grep -i wayland`
+if [ -n "$IS_WAYLAND" ]
+	then
+		export _JAVA_AWT_WM_NONREPARENTING=1
+fi
+
 #java -Xms4G -Xmx4G -ms4G -mx4G -XX:+UseParallelGC -classpath $jarpath projections.analysis.ProjMain $*
 java -Dapple.awt.application.name="Projections" -Xms2G -Xmx5G -ms2G -mx5G -classpath $jarpath projections.analysis.ProjMain ${1+"$@"}
 #java -classpath $jarpath projections.analysis.ProjMain $*

--- a/bin/projections
+++ b/bin/projections
@@ -12,8 +12,8 @@ fi
 
 IS_WAYLAND=`env | grep -i wayland`
 if [ -n "$IS_WAYLAND" ]
-	then
-		export _JAVA_AWT_WM_NONREPARENTING=1
+then
+  export _JAVA_AWT_WM_NONREPARENTING=1
 fi
 
 #java -Xms4G -Xmx4G -ms4G -mx4G -XX:+UseParallelGC -classpath $jarpath projections.analysis.ProjMain $*


### PR DESCRIPTION
Exporting `_JAVA_AWT_WM_NONREPARENTING=1` makes projections usable on wayland, without any graphical artifacts.