### PR TITLE
Only check for comm thread tracing when logs are from an SMP run

### DIFF
--- a/src/projections/analysis/StsReader.java
+++ b/src/projections/analysis/StsReader.java
@@ -286,7 +286,7 @@ public class StsReader extends ProjDefs
 			//indicate a non-SMP run
 			NumNodes = NumPe;		
 		}else{
-			isCommTracingEnabled = NodeSize * NumNodes < NumPe;
+			isCommTracingEnabled = (NodeSize * NumNodes) < NumPe;
 			int workPes = NumNodes*NodeSize;
 			NumCommThdPerNode = (NumPe-workPes)/NumNodes;
 			if((NodeSize+NumCommThdPerNode)*NumNodes != NumPe){
@@ -518,4 +518,3 @@ public class StsReader extends ProjDefs
 	}
 
 }
-

--- a/src/projections/analysis/StsReader.java
+++ b/src/projections/analysis/StsReader.java
@@ -282,11 +282,11 @@ public class StsReader extends ProjDefs
 	    InFile.close();
 	    
 		//post-processing for SMP related data fields
-		isCommTracingEnabled = NodeSize * NumNodes < NumPe;
 		if(NumNodes == 0){
 			//indicate a non-SMP run
 			NumNodes = NumPe;		
 		}else{
+			isCommTracingEnabled = NodeSize * NumNodes < NumPe;
 			int workPes = NumNodes*NodeSize;
 			NumCommThdPerNode = (NumPe-workPes)/NumNodes;
 			if((NodeSize+NumCommThdPerNode)*NumNodes != NumPe){


### PR DESCRIPTION
Previously, logs from non-SMP mode runs were erroneously classified as having comm thread tracing enabled since `numNodes` is 0 for those runs, so the pre-filled range in the range dialog was twice as big as it was supposed to be (`0-7` instead of `0-3`, for example, since every PE was thought to have a corresponding comm thread trace).