### PR TITLE
Timeline space/performance optimizations

### DIFF
--- a/src/projections/Tools/Timeline/Data.java
+++ b/src/projections/Tools/Timeline/Data.java
@@ -689,7 +689,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 					if (entryArray[i] == null) break;
 					topTimesText+=(i+1 +": " + (entryArray[i].getEndTime() - entryArray[i].getBeginTime()));
 					topTimesText+=(" Begin: " + entryArray[i].getBeginTime() + " End: " + entryArray[i].getEndTime());
-					topTimesText+=(" PE: " + entryArray[i].pe + " Name: " + MainWindow.runObject[myRun].getEntryFullNameByID(entryArray[i].getEntryID()) + "<br>");
+					topTimesText+=(" PE: " + entryArray[i].pe + " Name: " + MainWindow.runObject[myRun].getEntryFullNameByID(entryArray[i].getEntry()) + "<br>");
 					longestObjectsSet.add(entryArray[i]);
 				}
 				topTimesText+="</html>";

--- a/src/projections/Tools/Timeline/Data.java
+++ b/src/projections/Tools/Timeline/Data.java
@@ -770,7 +770,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 		
 		if (tleMsg!=null) {
 			for (int i=0; i<tleMsg.size(); i++) { //when to empty the drawMsgsForTheseObjsAlt?
-				Set<EntryMethodObject> entMethSet = this.messageStructures.getMessageToExecutingObjectsMap().get(tleMsg.get(i));
+				Set<EntryMethodObject> entMethSet = tleMsg.get(i).getRecipients();
 				if (entMethSet!=null) {					
 					Iterator<EntryMethodObject> iter = entMethSet.iterator();
 					while (iter.hasNext()) {

--- a/src/projections/Tools/Timeline/Data.java
+++ b/src/projections/Tools/Timeline/Data.java
@@ -670,7 +670,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 			{			
 				topTimesText = "<html>";
 				topTimesText+="The longest idle times in descending order are: <br>";
-				Set<EntryMethodObject> longestObjectsSet = new HashSet<EntryMethodObject>();
+				HashSet<EntryMethodObject> longestObjectsSet = new HashSet<EntryMethodObject>();
 				for (int i = 0; i < amountTopTimes(); i++)
 				{
 					if ((idleArray[i] == null) || (idleArray[i].getBeginTime() == objEndTimes[i]))
@@ -693,9 +693,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 					longestObjectsSet.add(entryArray[i]);
 				}
 				topTimesText+="</html>";
-				HashSet<Object> objsToHilite = new HashSet<Object>();
-				objsToHilite.addAll(longestObjectsSet);
-				highlightObjects(objsToHilite);
+				highlightObjects(longestObjectsSet);
 			}
 
 			// Spawn a thread that computes some secondary message related data structures
@@ -1521,7 +1519,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 	}
 
 	/** Highlight the given set of timeline objects */
-	protected void highlightObjects(Set<Object> objects) {
+	protected void highlightObjects(Collection<EntryMethodObject> objects) {
 		highlightedObjects.addAll(objects);
 	}
 
@@ -1529,7 +1527,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 	 * If there are any objects set to be highlighted, 
 	 * all others will be dimmed 
 	 */
-	protected boolean isObjectDimmed(Object o){
+	protected boolean isObjectDimmed(EntryMethodObject o){
 		if(highlightedObjects.size() == 0)
 			return false;
 		else

--- a/src/projections/Tools/Timeline/Data.java
+++ b/src/projections/Tools/Timeline/Data.java
@@ -770,7 +770,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 		
 		if (tleMsg!=null) {
 			for (int i=0; i<tleMsg.size(); i++) { //when to empty the drawMsgsForTheseObjsAlt?
-				Set<EntryMethodObject> entMethSet = tleMsg.get(i).getRecipients();
+				List<EntryMethodObject> entMethSet = tleMsg.get(i).getRecipients();
 				if (entMethSet!=null) {					
 					Iterator<EntryMethodObject> iter = entMethSet.iterator();
 					while (iter.hasNext()) {

--- a/src/projections/Tools/Timeline/Data.java
+++ b/src/projections/Tools/Timeline/Data.java
@@ -791,7 +791,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 
 		//recvCPe is a msg recv operation on CommThd
 		//trace back to its sender
-		EntryMethodObject recvCPe = messageStructures.getMessageToSendingObjectsMap().get(createdMsg);
+		EntryMethodObject recvCPe = createdMsg.getSender();
 		if(!recvCPe.isCommThreadMsgRecv()) return false;
 		createdMsg = recvCPe.creationMessage();
 		if(createdMsg == null){
@@ -799,7 +799,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 			return false;			 
 		}
 		//sendCPe should be a msg send operation on CommThd
-		EntryMethodObject sendCPe = messageStructures.getMessageToSendingObjectsMap().get(createdMsg);
+		EntryMethodObject sendCPe = createdMsg.getSender();
 		if(sendCPe == null) {
 			//this should never happen!!
 			return false;
@@ -816,7 +816,7 @@ public class Data implements ColorUpdateNotifier, EntryMethodVisibility
 			return false;			 
 		}
 
-		EntryMethodObject sendWPe = messageStructures.getMessageToSendingObjectsMap().get(createdMsg);
+		EntryMethodObject sendWPe = createdMsg.getSender();
 		if(sendWPe == null) {
 			//this should never happen!!
 			return false;

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -128,10 +128,21 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 
 		beginTime = tle.BeginTime;
 		elapsedTime = (int)(tle.EndTime - tle.BeginTime);
+		if (tle.EndTime - tle.BeginTime != elapsedTime) {
+			throw new IllegalArgumentException("Total time of entry method does not fit in type int");
+		}
 		// If the incoming RecvTime is 0, then it is invalid, so use MIN_VALUE to represent it in the offset
 		recvTimeOffset = (tle.RecvTime == 0) ? Integer.MIN_VALUE : (int)(tle.RecvTime - tle.BeginTime);
+		if (tle.RecvTime != 0 && tle.RecvTime - tle.BeginTime != recvTimeOffset) {
+			throw new IllegalArgumentException("Difference between receive time and begin time for entry method does not fit in type int");
+		}
 		cpuBegin = tle.cpuBegin;
-		cpuElapsed = (int)(tle.cpuEnd - tle.cpuBegin);
+		if (cpuBegin > 0) {
+			cpuElapsed = (int) (tle.cpuEnd - tle.cpuBegin);
+			if (tle.cpuEnd - tle.cpuBegin != cpuElapsed) {
+				throw new IllegalArgumentException("Total CPU time of entry method does not fit in type int");
+			}
+		}
 		messages  = msgs; // Set of TimelineMessage
 		if (messages != null) {
 			for (TimelineMessage msg : messages) {

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -40,7 +40,6 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 	// save space. Take care to convert to an unsigned int when using, as Java
 	// has no unsigned short type.
 	private short entryPoint;
-	private int msglen;
 	int EventID;
 	private ObjectId tid; 
 	int pe;
@@ -138,7 +137,6 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 		this.packs= packs;
 
 		EventID = tle.EventID;
-		msglen = tle.MsgLen;
 		if (tle.id != null) {
 			tid = ObjectId.createObjectId(tle.id);
 		} else {
@@ -167,11 +165,11 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 
 			infoString.append("<b>" + MainWindow.runObject[data.myRun].getEntryFullNameByID(entry, true) + "</b><br><br>"); 
 
-			if(msglen > 0) {
-				infoString.append("<i>Msg Len</i>: " + msglen + "<br>");
+			final TimelineMessage creationMessage = this.creationMessage();
+			if(creationMessage != null && creationMessage.MsgLen > 0) {
+				infoString.append("<i>Msg Len</i>: " + creationMessage.MsgLen + "<br>");
 			}
 
-			
 			infoString.append("<i>Begin Time</i>: " + format_.format(beginTime));
 			if (cpuElapsed > 0)
 				infoString.append(" (" + format_.format(cpuBegin) + ")");
@@ -196,16 +194,15 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 				infoString.append("<i>Msgs created</i>: " + messages.size() + "<br>");
 			else 
 				infoString.append("<i>Msgs created</i>: 0<br>");
-
-			TimelineMessage created_message = this.creationMessage();
+			
 			boolean usedCommThreadSender = false;
-			if(created_message != null)
+			if(creationMessage != null)
 			{
-				infoString.append("<i>Msg latency is </i>: " + (beginTime - created_message.Time) + "<br>");
+				infoString.append("<i>Msg latency is </i>: " + (beginTime - creationMessage.Time) + "<br>");
 
 				// If the message came from a comm thread, trace back to the actual creator if possible
 				if (data.isCommThd(pCreation)) {
-					final EntryMethodObject commThreadSender = created_message.getSender();
+					final EntryMethodObject commThreadSender = creationMessage.getSender();
 					if (commThreadSender != null) {
 						TimelineMessage origMsg = commThreadSender.creationMessage();
 						if (origMsg != null) {

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -559,7 +559,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 							//if there is a mapping for this message, find objects that are called by this message.
 							//if this object isn't null or equal to this, go through while loop again
                             //data.addProcessor( mm); 
-							Set<EntryMethodObject> objset = data.messageStructures.getMessageToExecutingObjectsMap().get(msgToCalledEntryMethod);
+							Set<EntryMethodObject> objset = msgToCalledEntryMethod.getRecipients();
                             //System.out.println("fowarding  " + j + "; obj ");
                             //msgToCalledEntryMethod.printMe();
 

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -140,9 +140,9 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 		EventID = tle.EventID;
 		msglen = tle.MsgLen;
 		if (tle.id != null) {
-			tid = new ObjectId(tle.id);
+			tid = ObjectId.createObjectId(tle.id);
 		} else {
-			tid = new ObjectId();
+			tid = ObjectId.createObjectId();
 		}
 		
 		if (tle.UserSpecifiedData != null || tle.memoryUsage > 0 ||

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -911,7 +911,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 
 		 */
 
-		if(data.showPacks() && packs != null)
+		if(packs != null && data.showPacks())
 		{
 			g2d.setColor(Color.pink);
 			for(PackTime pt : packs){
@@ -938,7 +938,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 
 		// Show the message sends. See note above for the message packing areas
 		// Don't change this without changing MainPanel's paintComponent which draws message send lines
-		if(data.showMsgs() == true && messages != null)
+		if(messages != null && data.showMsgs())
 		{
 			g2d.setColor(data.getForegroundColor());
 			

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -452,9 +452,9 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
                 Set<EntryMethodObject> back = traceBackwardDependencies();// this function acts differently depending on data.traceMessagesBackOnHover()
                 Set<EntryMethodObject> criticalpath = traceCriticalPathDependencies();// this function acts differently depending on data.traceMessagesBackOnHover()
 
-                HashSet<Object> fwdGeneric = new HashSet<Object>();
-                HashSet<Object> backGeneric =  new HashSet<Object>();
-                HashSet<Object> criticalpathGeneric =  new HashSet<Object>();
+                HashSet<EntryMethodObject> fwdGeneric = new HashSet<>();
+                HashSet<EntryMethodObject> backGeneric =  new HashSet<>();
+                HashSet<EntryMethodObject> criticalpathGeneric =  new HashSet<>();
                 fwdGeneric.addAll(fwd); // this function acts differently depending on data.traceMessagesForwardOnHover()
                 backGeneric.addAll(back); // this function acts differently depending on data.traceMessagesBackOnHover()
                 criticalpathGeneric.addAll(criticalpath); // this function acts differently depending on data.traceCriticalPathOnHover()
@@ -734,7 +734,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 		// Highlight any Entry Method invocations for the same chare array element
 		if(data.traceOIDOnHover()){
 			synchronized(data.messageStructures){
-			Set allWithSameId = (Set) data.messageStructures.getOidToEntryMethodObjectsMap().get(tid);
+			List<EntryMethodObject> allWithSameId = data.messageStructures.getOidToEntryMethodObjectsMap().get(tid);
 			data.highlightObjects(allWithSameId);
 			needRepaint=true;
 			}

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -12,6 +12,7 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import javax.swing.JColorChooser;
@@ -559,7 +560,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 							//if there is a mapping for this message, find objects that are called by this message.
 							//if this object isn't null or equal to this, go through while loop again
                             //data.addProcessor( mm); 
-							Set<EntryMethodObject> objset = msgToCalledEntryMethod.getRecipients();
+							List<EntryMethodObject> objset = msgToCalledEntryMethod.getRecipients();
                             //System.out.println("fowarding  " + j + "; obj ");
                             //msgToCalledEntryMethod.printMe();
 

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -89,6 +89,11 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 		entry     = tle.EntryPoint;
 		entryIndex = MainWindow.runObject[data.myRun].getEntryIndex(entry);
 		messages  = msgs; // Set of TimelineMessage
+		if (messages != null) {
+			for (TimelineMessage msg : messages) {
+				msg.setSender(this);
+			}
+		}
 		this.packs= packs;
 		pe  = p1;
 		pCreation = tle.SrcPe;
@@ -169,12 +174,15 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 
 				// If the message came from a comm thread, trace back to the actual creator if possible
 				if (data.isCommThd(pCreation)) {
-					TimelineMessage origMsg = data.messageStructures.getMessageToSendingObjectsMap().get(created_message).creationMessage();
-					if (origMsg != null) {
-						EntryMethodObject origSender = data.messageStructures.getMessageToSendingObjectsMap().get(origMsg);
-						if (origSender != null) {
-							infoString.append("<i>Created by </i>: " + data.getPEString(origSender.pe) + " via " + data.getPEString(pCreation) + "<br>");
-							usedCommThreadSender = true;
+					final EntryMethodObject commThreadSender = created_message.getSender();
+					if (commThreadSender != null) {
+						TimelineMessage origMsg = commThreadSender.creationMessage();
+						if (origMsg != null) {
+							EntryMethodObject origSender = origMsg.getSender();
+							if (origSender != null) {
+								infoString.append("<i>Created by </i>: " + data.getPEString(origSender.pe) + " via " + data.getPEString(pCreation) + "<br>");
+								usedCommThreadSender = true;
+							}
 						}
 					}
 				}
@@ -507,7 +515,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 						if(created_message != null){
 							if ( obj.beginTime - created_message.Time > max_time) { max_time = obj.beginTime - created_message.Time; begin_max = created_message.Time;}
                             // Find object that created the message
-							obj = data.messageStructures.getMessageToSendingObjectsMap().get(created_message);
+							obj = created_message.getSender();
 							if(obj != null){
 								done = false;
 							}else
@@ -611,7 +619,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
                             data.addProcessor(obj.pCreation);
 						    TimelineMessage created_message = obj.creationMessage();
                             if(created_message != null) {
-                                obj = data.messageStructures.getMessageToSendingObjectsMap().get(created_message);
+                                obj = created_message.getSender();
                                 if(obj != null){
                                     System.out.println("Switch to other processor");
                                     done = false;

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -798,13 +798,14 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 	
 /** Whether this object is displayed or hidden (for example when idle's are not displayed this might be false) */
 	public boolean isDisplayed() {
+		final int entry = getEntry();
 		// If it is hidden, we may not display it
-		if(data.entryIsHiddenID(getEntry())) {
+		if(data.entryIsHiddenID(entry)) {
 			return false;
 		}
 		
 		// If this is an idle time region, we may not display it
-		if (isIdleEvent() && (!data.showIdle() || MainWindow.IGNORE_IDLE)) {
+		if (entry == Analysis.IDLE_ENTRY_POINT && (!data.showIdle() || MainWindow.IGNORE_IDLE)) {
 			return false;
 		}
 

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -812,7 +812,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 	}
 	
 	
-	public boolean paintMe(Graphics2D g2d, int actualDisplayWidth, MainPanel.MaxFilledX maxFilledX){
+	public boolean paintMe(Graphics2D g2d, final int actualDisplayWidth, final int topCoord, MainPanel.MaxFilledX maxFilledX){
 		boolean paintedEP = false;
 		// If it is hidden, we may not display it
 		if(!isDisplayed()){
@@ -828,9 +828,6 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 
 		if(beginTime < data.startTime())
 			leftCoord = data.timeToScreenPixelLeft(data.startTime(), actualDisplayWidth);
-
-		int topCoord = data.entryMethodLocationTop(pe);
-//		int height = data.entryMethodLocationHeight();
 
 		// Determine the coordinates and sizes of the components of the graphical representation of the object
 		int rectWidth = Math.max(1, rightCoord - leftCoord + 1);

--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -1118,7 +1118,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 		{   
 			for(PackTime pt : packs){
 				// packtime += packs[p].EndTime - packs[p].BeginTime + 1;
-				packtime += pt.EndTime - pt.BeginTime;
+				packtime += (int)(pt.EndTime - pt.BeginTime);
 				if(pt.BeginTime < data.startTime())
 					packtime -= (data.startTime() - pt.BeginTime);
 				if(pt.EndTime > data.endTime())

--- a/src/projections/Tools/Timeline/MainPanel.java
+++ b/src/projections/Tools/Timeline/MainPanel.java
@@ -249,10 +249,11 @@ public class MainPanel extends JPanel  implements Scrollable, MouseListener, Mou
 				// Saves the furthest right position EPs and msg lines have been drawn in
 				// order to optimize performance by only drawing when new pixels will be colored in
 				MaxFilledX maxFilledX = new MaxFilledX();
+				final int topCoord = data.entryMethodLocationTop(pe);
 
 				while(iter.hasNext()){
 					EntryMethodObject o = iter.next();
-					if(o.paintMe((Graphics2D) g, getWidth(), maxFilledX)) {
+					if(o.paintMe((Graphics2D) g, getWidth(), topCoord, maxFilledX)) {
 						count1++;
 					}
 				}
@@ -270,11 +271,13 @@ public class MainPanel extends JPanel  implements Scrollable, MouseListener, Mou
 			for(Integer pe : pesToRender){
 				Query1D<UserEventObject> l = data.allUserEventObjects.get(pe);
 
+				final int bottomCoord = data.userEventLocationBottom(pe);
+
 				if(l != null){ // FIXME: this shouldn't be here but is to fix a race condition with reloading ranges once something is displayed
 					Iterator<UserEventObject> iter = l.iterator(leftClipTime, rightClipTime);
 					while(iter.hasNext()){
 						UserEventObject o = iter.next();
-						o.paintMe((Graphics2D) g, getWidth(), data);
+						o.paintMe((Graphics2D) g, getWidth(), data, bottomCoord);
 						count2 ++;
 					}
 				}

--- a/src/projections/Tools/Timeline/MessagePanel.java
+++ b/src/projections/Tools/Timeline/MessagePanel.java
@@ -91,7 +91,7 @@ class MessagePanel extends JPanel {
     }
 
     private void createLayout() {
-	epLabel = new JLabel(MainWindow.runObject[myRun].getEntryFullNameByID(obj.getEntryID()), JLabel.CENTER);
+	epLabel = new JLabel(MainWindow.runObject[myRun].getEntryFullNameByID(obj.getEntry()), JLabel.CENTER);
 	beginTimeField = new LabelPanel("BEGIN TIME:",
 					new JLongTextField(obj.getBeginTime(),
 							   10));

--- a/src/projections/Tools/Timeline/MessagePanel.java
+++ b/src/projections/Tools/Timeline/MessagePanel.java
@@ -82,7 +82,7 @@ class MessagePanel extends JPanel {
     			tableData[row][1] = df.format(msg.MsgLen);
     			tableData[row][2] = df.format(msg.Time);
     			tableData[row][3] = df.format((row>0) ? (msg.Time - prev.Time) : (msg.Time - obj.getBeginTime()) );
-    			tableData[row][4] = MainWindow.runObject[myRun].getEntryNameByID(msg.Entry);								 
+    			tableData[row][4] = MainWindow.runObject[myRun].getEntryNameByID(msg.getEntry());								 
     			tableData[row][5] = msg.destination(MainWindow.runObject[myRun].getNumProcessors());
 
     			row++;

--- a/src/projections/Tools/Timeline/MessageStructures.java
+++ b/src/projections/Tools/Timeline/MessageStructures.java
@@ -34,9 +34,6 @@ class MessageStructures {
 	/** Map from a message to the the resulting entry methods entry object invocations */
 	private Map<TimelineMessage, Set<EntryMethodObject>> messageToExecutingObjectsMap;
 
-	/** Map from a message to its invoking entry method instance */
-	private Map<TimelineMessage, EntryMethodObject> messageToSendingObjectsMap;
-
 	/** Map from Chare Array element id's to the corresponding known entry method invocations */
 	private Map<ObjectId, List<EntryMethodObject> > oidToEntryMethodObjectsMap;
 
@@ -62,7 +59,6 @@ class MessageStructures {
 			for(int i=0;i<pe;i++)
 				eventIDToEntryMethodMap[i] = new HashMap();
 
-			messageToSendingObjectsMap = new HashMap<TimelineMessage, EntryMethodObject>();
 			messageToExecutingObjectsMap = new HashMap<TimelineMessage, Set<EntryMethodObject>>();
 
 			oidToEntryMethodObjectsMap = new TreeMap();
@@ -92,10 +88,6 @@ class MessageStructures {
 		return eventIDToMessageMap;
 	}
 
-	public Map<TimelineMessage, EntryMethodObject> getMessageToSendingObjectsMap() {
-		return messageToSendingObjectsMap;
-	}
-
 	public void setOidToEntryMethodObjectsMap(Map oidToEntryMethodObjectsMap) {
 		this.oidToEntryMethodObjectsMap = oidToEntryMethodObjectsMap;
 	}
@@ -119,10 +111,6 @@ class MessageStructures {
 
 	public Map<TimelineMessage, Set<EntryMethodObject>> getMessageToExecutingObjectsMap() {
 		return messageToExecutingObjectsMap;
-	}
-
-	public void setMessageToSendingObjectsMap(Map<TimelineMessage, EntryMethodObject> messageToSendingObjectsMap) {
-		this.messageToSendingObjectsMap = messageToSendingObjectsMap;
 	}
 
 	protected void kill() {
@@ -178,32 +166,6 @@ class MessageStructures {
 				EntryMethodObject obj = obj_iter.next();
 				getEventIDToEntryMethodMap()[pe.intValue()].put(Integer.valueOf(obj.EventID), obj);
 			}
-		}
-
-
-		/** Create a mapping from TimelineMessage objects to their creator EntryMethod's */
-
-		pe_iter = data.allEntryMethodObjects.keySet().iterator();
-		while(pe_iter.hasNext()){
-			
-			if(structures!=null) {
-				synchronized(structures){
-					if(structures.stop)
-						return;					
-				}
-			}	
-			
-			Integer pe =  pe_iter.next();
-			Query1D<EntryMethodObject> objs = data.allEntryMethodObjects.get(pe);
-
-			for(EntryMethodObject obj : objs) {
-				if(obj.messages != null){
-					for(TimelineMessage msg : obj.messages) {
-						// put all the messages created by obj into the map, listing obj as the creator
-						getMessageToSendingObjectsMap().put(msg, obj);
-					}
-				}
-			}				
 		}
 
 
@@ -289,7 +251,6 @@ class MessageStructures {
 				eventIDToMessageMap[i].clear();
 			for(int i=0;i<pe;i++)
 				eventIDToEntryMethodMap[i].clear();
-			messageToSendingObjectsMap.clear();
 			messageToExecutingObjectsMap.clear();
 			oidToEntryMethodObjectsMap.clear();
 		}		

--- a/src/projections/Tools/Timeline/MessageStructures.java
+++ b/src/projections/Tools/Timeline/MessageStructures.java
@@ -30,10 +30,7 @@ class MessageStructures {
 
 	/** A Map for each PE, key = eventID value = EntryMethodObject */
 	private Map<Integer, EntryMethodObject> []eventIDToEntryMethodMap;
-
-	/** Map from a message to the the resulting entry methods entry object invocations */
-	private Map<TimelineMessage, Set<EntryMethodObject>> messageToExecutingObjectsMap;
-
+	
 	/** Map from Chare Array element id's to the corresponding known entry method invocations */
 	private Map<ObjectId, List<EntryMethodObject> > oidToEntryMethodObjectsMap;
 
@@ -58,9 +55,7 @@ class MessageStructures {
 			eventIDToEntryMethodMap = new HashMap[pe];
 			for(int i=0;i<pe;i++)
 				eventIDToEntryMethodMap[i] = new HashMap();
-
-			messageToExecutingObjectsMap = new HashMap<TimelineMessage, Set<EntryMethodObject>>();
-
+			
 			oidToEntryMethodObjectsMap = new TreeMap();
 		}		
 	}
@@ -103,16 +98,7 @@ class MessageStructures {
 	public Map [] getEventIDToEntryMethodMap() {
 		return eventIDToEntryMethodMap;
 	}
-
-	public void setMessageToExecutingObjectsMap(
-			Map<TimelineMessage, Set<EntryMethodObject>> messageToExecutingObjectsMap) {
-		this.messageToExecutingObjectsMap = messageToExecutingObjectsMap;
-	}
-
-	public Map<TimelineMessage, Set<EntryMethodObject>> getMessageToExecutingObjectsMap() {
-		return messageToExecutingObjectsMap;
-	}
-
+	
 	protected void kill() {
 		if(secondaryWorkers != null){
 			secondaryWorkers.stopThread();
@@ -189,18 +175,7 @@ class MessageStructures {
 
 				TimelineMessage msg = obj.creationMessage();
 				if(msg!=null){
-					// for each EntryMethodObject, add its creation Message to the map
-					if(getMessageToExecutingObjectsMap().containsKey(msg)){
-						// add it to the TreeSet in the map
-						Object o= getMessageToExecutingObjectsMap().get(msg);
-						TreeSet<EntryMethodObject> ts = (TreeSet<EntryMethodObject>)o;
-						ts.add(obj);
-					} else {
-						// create a new TreeSet and put it in the map
-						TreeSet<EntryMethodObject> ts = new TreeSet<EntryMethodObject>();
-						ts.add(obj);
-						getMessageToExecutingObjectsMap().put(msg, ts);
-					}
+					msg.addRecipient(obj);
 				}
 
 			}
@@ -251,7 +226,6 @@ class MessageStructures {
 				eventIDToMessageMap[i].clear();
 			for(int i=0;i<pe;i++)
 				eventIDToEntryMethodMap[i].clear();
-			messageToExecutingObjectsMap.clear();
 			oidToEntryMethodObjectsMap.clear();
 		}		
 	}

--- a/src/projections/Tools/Timeline/MessageStructures.java
+++ b/src/projections/Tools/Timeline/MessageStructures.java
@@ -1,12 +1,11 @@
 package projections.Tools.Timeline;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 import projections.Tools.Timeline.RangeQueries.Query1D;
 import projections.analysis.ObjectId;
@@ -56,7 +55,7 @@ class MessageStructures {
 			for(int i=0;i<pe;i++)
 				eventIDToEntryMethodMap[i] = new HashMap();
 			
-			oidToEntryMethodObjectsMap = new TreeMap();
+			oidToEntryMethodObjectsMap = new TreeMap<>();
 		}		
 	}
 
@@ -87,7 +86,7 @@ class MessageStructures {
 		this.oidToEntryMethodObjectsMap = oidToEntryMethodObjectsMap;
 	}
 
-	public Map getOidToEntryMethodObjectsMap() {
+	public Map<ObjectId, List<EntryMethodObject>> getOidToEntryMethodObjectsMap() {
 		return oidToEntryMethodObjectsMap;
 	}
 
@@ -204,11 +203,11 @@ class MessageStructures {
 
 					if(getOidToEntryMethodObjectsMap().containsKey(id)){
 						// add obj to the existing set
-						TreeSet<EntryMethodObject> s = (TreeSet<EntryMethodObject>) getOidToEntryMethodObjectsMap().get(id);
+						List<EntryMethodObject> s = getOidToEntryMethodObjectsMap().get(id);
 						s.add(obj);
 					} else {
 						// create a set for the id
-						TreeSet<EntryMethodObject> s = new TreeSet<EntryMethodObject>();
+						ArrayList<EntryMethodObject> s = new ArrayList<EntryMethodObject>();
 						s.add(obj);
 						getOidToEntryMethodObjectsMap().put(id, s);
 					}

--- a/src/projections/Tools/Timeline/RangeQueries/MergedIterator.java
+++ b/src/projections/Tools/Timeline/RangeQueries/MergedIterator.java
@@ -1,40 +1,44 @@
 package projections.Tools.Timeline.RangeQueries;
 
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.NoSuchElementException;
 
-public class MergedIterator<E> implements Iterator<E>{
+public final class MergedIterator<E> implements Iterator<E> {
 	private final Iterator<E> iterators[];
 	private int index;
+	private boolean internalHasNext;
 
-	public MergedIterator(Iterator<E>... iters){
+	public MergedIterator(Iterator<E>... iters) {
 		iterators = iters;
 		index = 0;
+		loadHasNext();
 	}
-	
-	
+
 	@Override
-	public boolean hasNext() {
+	public final boolean hasNext() {
+		return internalHasNext;
+	}
+
+	@Override
+	public final E next() {
+		if (internalHasNext) {
+			E next = iterators[index].next();
+			loadHasNext();
+			return next;
+		}
+		else
+			throw new NoSuchElementException();
+	}
+
+	private final void loadHasNext() {
 		while (index < iterators.length && !iterators[index].hasNext()) {
 			index++;
 		}
-
-		return index < iterators.length;
+		internalHasNext = index < iterators.length;
 	}
 
 	@Override
-	public E next() {
-		if (hasNext()) {
-			return iterators[index].next();
-		}
-
-		throw new NoSuchElementException();
-	}
-
-	@Override
-	public void remove() {
+	public final void remove() {
 		throw new UnsupportedOperationException();
 	}
-
 }

--- a/src/projections/Tools/Timeline/TimelineMessage.java
+++ b/src/projections/Tools/Timeline/TimelineMessage.java
@@ -2,6 +2,9 @@ package projections.Tools.Timeline;
 
 import projections.misc.MiscUtil;
 
+import java.util.Set;
+import java.util.TreeSet;
+
 
 public class TimelineMessage implements Comparable
 {
@@ -26,6 +29,7 @@ public class TimelineMessage implements Comparable
 	// created. If this is null, then there is no known sender (which can happen
 	// for dummy sends, for example)
 	private EntryMethodObject sender;
+	private Set<EntryMethodObject> recipients;
 
 	/** A messages sent from srcPE, with eventid EventID */
 
@@ -118,5 +122,17 @@ public class TimelineMessage implements Comparable
 
 	protected EntryMethodObject getSender() {
 		return sender;
+	}
+
+	protected void addRecipient(EntryMethodObject obj) {
+		synchronized (this) {
+			if (recipients == null)
+				recipients = new TreeSet<>();
+			recipients.add(obj);
+		}
+	}
+
+	protected Set<EntryMethodObject> getRecipients() {
+		return recipients;
 	}
 }

--- a/src/projections/Tools/Timeline/TimelineMessage.java
+++ b/src/projections/Tools/Timeline/TimelineMessage.java
@@ -11,7 +11,7 @@ public class TimelineMessage implements Comparable
 	/** Message send time */
 	protected long Time;
 	
-	protected int Entry;
+	private short Entry;
 	
 	/** Message Length */
 	protected int MsgLen;
@@ -42,7 +42,7 @@ public class TimelineMessage implements Comparable
 	public TimelineMessage(int srcPE, long t, int e, int mlen, int EventID, int destPEs[]) {
 		this.srcPE = srcPE;
 		Time=t;
-		Entry=e;
+		Entry=(short)e;
 		MsgLen=mlen;
 		this.EventID = EventID;
 		if (destPEs != null) {
@@ -57,7 +57,7 @@ public class TimelineMessage implements Comparable
 	public TimelineMessage(int srcPE, long t, int e, int mlen, int EventID, int numPEs) {
 		Time=t;
 		this.srcPE = srcPE;
-		Entry=e;
+		Entry=(short)e;
 		MsgLen=mlen;
 		this.EventID = EventID;
 		this.numPEs = numPEs;
@@ -134,5 +134,9 @@ public class TimelineMessage implements Comparable
 
 	protected List<EntryMethodObject> getRecipients() {
 		return recipients;
+	}
+
+	protected int getEntry() {
+		return Short.toUnsignedInt(Entry);
 	}
 }

--- a/src/projections/Tools/Timeline/TimelineMessage.java
+++ b/src/projections/Tools/Timeline/TimelineMessage.java
@@ -126,8 +126,10 @@ public class TimelineMessage implements Comparable
 
 	protected void addRecipient(EntryMethodObject obj) {
 		synchronized (this) {
-			if (recipients == null)
-				recipients = new ArrayList<>();
+			if (recipients == null) {
+				// Set initialCapacity to 1 to prevent recipients from allocating more memory than needed
+				recipients = new ArrayList<>(1);
+			}
 			recipients.add(obj);
 		}
 	}

--- a/src/projections/Tools/Timeline/TimelineMessage.java
+++ b/src/projections/Tools/Timeline/TimelineMessage.java
@@ -22,6 +22,11 @@ public class TimelineMessage implements Comparable
 
 	private int srcPE;
 
+	// The sending EntryMethodObject will set this field via setSender when it is
+	// created. If this is null, then there is no known sender (which can happen
+	// for dummy sends, for example)
+	private EntryMethodObject sender;
+
 	/** A messages sent from srcPE, with eventid EventID */
 
 	/** Single message constructor */
@@ -107,5 +112,11 @@ public class TimelineMessage implements Comparable
 		Time += shift;
 	}
 	
-	
+	protected void setSender(EntryMethodObject obj) {
+		sender = obj;
+	}
+
+	protected EntryMethodObject getSender() {
+		return sender;
+	}
 }

--- a/src/projections/Tools/Timeline/TimelineMessage.java
+++ b/src/projections/Tools/Timeline/TimelineMessage.java
@@ -2,8 +2,8 @@ package projections.Tools.Timeline;
 
 import projections.misc.MiscUtil;
 
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class TimelineMessage implements Comparable
@@ -29,7 +29,7 @@ public class TimelineMessage implements Comparable
 	// created. If this is null, then there is no known sender (which can happen
 	// for dummy sends, for example)
 	private EntryMethodObject sender;
-	private Set<EntryMethodObject> recipients;
+	private List<EntryMethodObject> recipients;
 
 	/** A messages sent from srcPE, with eventid EventID */
 
@@ -127,12 +127,12 @@ public class TimelineMessage implements Comparable
 	protected void addRecipient(EntryMethodObject obj) {
 		synchronized (this) {
 			if (recipients == null)
-				recipients = new TreeSet<>();
+				recipients = new ArrayList<>();
 			recipients.add(obj);
 		}
 	}
 
-	protected Set<EntryMethodObject> getRecipients() {
+	protected List<EntryMethodObject> getRecipients() {
 		return recipients;
 	}
 }

--- a/src/projections/Tools/Timeline/UserEventObject.java
+++ b/src/projections/Tools/Timeline/UserEventObject.java
@@ -115,7 +115,7 @@ public class UserEventObject implements Comparable, Range1D, ActionListener, Mai
 		return nestedID;
 	}
 
-	protected void paintMe(Graphics2D g, int actualDisplayWidth, Data data) {
+	protected void paintMe(Graphics2D g, int actualDisplayWidth, Data data, final int baseBottomCoord) {
 
 		if(data.userEventIsHiddenID(userEventID)){
 			return;
@@ -135,9 +135,9 @@ public class UserEventObject implements Comparable, Range1D, ActionListener, Mai
 
 		if(width < 1)
 			width = 1;
-		
-		int topCoord = data.userEventLocationBottom(pe) - (1+nestedRow) * data.singleUserEventRectHeight();
+
 		int height = data.singleUserEventRectHeight();
+		int topCoord = baseBottomCoord - (1+nestedRow) * height;
 		int bottomCoord = topCoord+height-1;
 		
 		Color c = getColor(data);

--- a/src/projections/Tools/Timeline/UserSuppliedAnalyzer.java
+++ b/src/projections/Tools/Timeline/UserSuppliedAnalyzer.java
@@ -34,7 +34,7 @@ class UserSuppliedAnalyzer extends JFrame {
 		
 		for(Query1D<EntryMethodObject> objs : data.allEntryMethodObjects.values()){
 			for(EntryMethodObject obj : objs){
-				Integer param = obj.userSuppliedData;
+				Integer param = obj.getUserSuppliedData();
 				long start = obj.getBeginTime();
 				long end = obj.getEndTime();
 				

--- a/src/projections/analysis/Analysis.java
+++ b/src/projections/analysis/Analysis.java
@@ -7,7 +7,6 @@ import java.awt.Paint;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 import java.util.SortedSet;
 
 import javax.swing.SwingWorker;
@@ -102,8 +101,8 @@ public class Analysis {
   
   Paint overhead = new GradientPaint(0, 0, Color.black, 15, -25, new Color(50,50,50), true);
   Paint idle = new GradientPaint(0, 0, Color.white, 15, 25, new Color(230,230,230), true);
-  public static int isOverhead = -2;
-  public static int isIdle = -1;
+  public static final int OVERHEAD_ENTRY_POINT = -2;
+  public static final int IDLE_ENTRY_POINT = -1;
   
   public TachyonShifts tachyonShifts;
   
@@ -362,14 +361,14 @@ public class Analysis {
         return intervalData.sumDetailData();
     }
     public Color getEntryColor(int entryIdx) {
-    	if (entryIdx == isIdle) {
+    	if (entryIdx == IDLE_ENTRY_POINT) {
     		Paint p = getIdleColor();
     		if (p instanceof GradientPaint)
     			return ((GradientPaint)p).getColor1();
     		else
     			return (Color)p;
     	}
-    	else if (entryIdx == isOverhead) {
+    	else if (entryIdx == OVERHEAD_ENTRY_POINT) {
     		Paint p = getOverheadColor();
     		if (p instanceof GradientPaint)
     			return ((GradientPaint)p).getColor1();
@@ -385,9 +384,9 @@ public class Analysis {
 
 
     public void setEntryColor(int entryIdx, Color color) {
-    	if (entryIdx == isIdle)
+    	if (entryIdx == IDLE_ENTRY_POINT)
     		idle = color;
-    	else if (entryIdx == isOverhead)
+    	else if (entryIdx == OVERHEAD_ENTRY_POINT)
     		overhead = color;
     	else if (entryIdx < getSts().getEntryCount())
     		entryColors[entryIdx] = color;

--- a/src/projections/analysis/LogLoader.java
+++ b/src/projections/analysis/LogLoader.java
@@ -180,7 +180,7 @@ public class LogLoader extends ProjDefs
 						timeline.add(TE=
 							new TimelineEvent(lastBeginEvent.time,
 									LE.time,
-									-1, -1));
+									Analysis.IDLE_ENTRY_POINT, -1));
 					}
 					return;
 				default:
@@ -201,7 +201,7 @@ public class LogLoader extends ProjDefs
 							timeline.add(TE=
 								new TimelineEvent(lastBeginEvent.time,
 										End,
-										-1, -1));
+										Analysis.IDLE_ENTRY_POINT, -1));
 							break;
 						}
 					} else {
@@ -217,7 +217,7 @@ public class LogLoader extends ProjDefs
 			CallStackManager cstack = new CallStackManager();
 			ObjectId tid = null;
 			while(true) {
-				if (LE.entry != -1) {
+				if (LE.entry != Analysis.IDLE_ENTRY_POINT) {
 					switch (LE.type) {
 					case BEGIN_PROCESSING:
 						
@@ -324,7 +324,7 @@ public class LogLoader extends ProjDefs
 						if (TE == null) { 
 							TE = new TimelineEvent(LE.time,
 									LE.time,
-									-2,LE.pe,LE.msglen);
+									Analysis.OVERHEAD_ENTRY_POINT,LE.pe,LE.msglen);
 							timeline.add(TE);
 							tempte = true;
 						}
@@ -356,7 +356,7 @@ public class LogLoader extends ProjDefs
 						if (TE == null) {
 							TE = new TimelineEvent(LE.time,
 									LE.time,
-									-2, LE.pe, LE.msglen);
+									Analysis.OVERHEAD_ENTRY_POINT, LE.pe, LE.msglen);
 							timeline.add(TE);
 							tempte = true;
 						}
@@ -388,7 +388,7 @@ public class LogLoader extends ProjDefs
 						if (TE == null) {
 							TE = new TimelineEvent(LE.time,
 									LE.time,
-									-2, LE.pe, LE.msglen);
+									Analysis.OVERHEAD_ENTRY_POINT, LE.pe, LE.msglen);
 							timeline.add(TE);
 							tempte = true;
 						}
@@ -504,7 +504,7 @@ public class LogLoader extends ProjDefs
 						// Start a new dummy event
 						if (TE == null) {
 							TE = new TimelineEvent(LE.time,
-									LE.time,-2,
+									LE.time,Analysis.OVERHEAD_ENTRY_POINT,
 									LE.pe);
 							timeline.add(TE);
 						}
@@ -516,7 +516,7 @@ public class LogLoader extends ProjDefs
 						}
 						PT=null;
 						if (TE != null) {
-							if (TE.EntryPoint == -2) {
+							if (TE.EntryPoint == Analysis.OVERHEAD_ENTRY_POINT) {
 								TE=null;
 							}
 						}
@@ -528,7 +528,7 @@ public class LogLoader extends ProjDefs
 						}
 						TE = new TimelineEvent(LE.time,
 								Long.MAX_VALUE,
-								-1,-1); 
+								Analysis.IDLE_ENTRY_POINT,-1); 
 						timeline.add(TE);
 						break;
 					case END_IDLE:
@@ -544,7 +544,7 @@ public class LogLoader extends ProjDefs
 								(lastBeginEvent.type == BEGIN_IDLE)) {
 							TE = new TimelineEvent(lastBeginEvent.time,
 									End,
-									-1, -1);
+									Analysis.IDLE_ENTRY_POINT, -1);
 							timeline.add(TE);
 							isProcessing = true;
 						}
@@ -563,7 +563,7 @@ public class LogLoader extends ProjDefs
 				LE = reader.nextEvent(LE);
 				// this will
 				// END COMPUTATION event.
-				if (LE.entry != -1) {
+				if (LE.entry != Analysis.IDLE_ENTRY_POINT) {
 					if (LE.time > End) {
 						break;
 					}
@@ -573,7 +573,7 @@ public class LogLoader extends ProjDefs
 			// check to see if we are stopping in the middle of a message.
 			// if so, we need to keep reading to get its end time
 			while (TE != null) {
-				if (LE.entry != -1) {
+				if (LE.entry != Analysis.IDLE_ENTRY_POINT) {
 					if (LE.type == END_PROCESSING) {
 						TE.EndTime = LE.time;
 						// If the entry was not long enough, remove it from the timeline

--- a/src/projections/analysis/ObjectId.java
+++ b/src/projections/analysis/ObjectId.java
@@ -1,35 +1,46 @@
 package projections.analysis;
 
-public class ObjectId implements Comparable
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class ObjectId implements Comparable
 {
     private final static int ID_SIZE = 6;
-    public int id[];
+    public final int id[];
 
-    public ObjectId() {
-        id = new int[ID_SIZE];
-        id[0] = id[1] = id[2] = id[3] = id[4] = id[5] = -1;
-    }
-    public ObjectId(ObjectId d) {
-        if (d!=null) id = d.id.clone();
-        else {
-            id = new int[ID_SIZE];
-            id[0] = id[1] = id[2] = id[3] = id[4] = id[5] = -1;
-        }
-    }
+    private static ConcurrentHashMap<ObjectId, ObjectId> instances = new ConcurrentHashMap<>();
 
-    protected ObjectId(int[] data) {
+    private ObjectId(final int[] data) {
         if (data.length > ID_SIZE)
             throw new IndexOutOfBoundsException("Attempted to assign " + data.length + "elements to ID of size " + ID_SIZE);
         id = new int[ID_SIZE];
-        for (int i = 0; i < data.length; i++) {
+        for (int i = 0; i < ID_SIZE; i++) {
             id[i] = data[i];
         }
     }
 
+    public static ObjectId createObjectId() {
+        final int[] dummy = new int[ID_SIZE];
+        dummy[0] = dummy[1] = dummy[2] = dummy[3] = dummy[4] = dummy[5] = -1;
+        return createObjectId(dummy);
+    }
+
+    public static ObjectId createObjectId(ObjectId d) {
+        if (d == null)
+            return createObjectId();
+        else return d;
+    }
+
+    protected static ObjectId createObjectId(final int[] data) {
+        ObjectId candidate = new ObjectId(data);
+        ObjectId canonical = instances.putIfAbsent(candidate, candidate);
+        if (canonical == null)
+            canonical = candidate;
+        return canonical;
+    }
+
     public boolean equals(ObjectId comp) {
-        System.out.println("EQUALS");
-        return (id[0] == comp.id[0]) && (id[1] == comp.id[1]) && (id[2] == comp.id[2]) &&
-               (id[3] == comp.id[3]) && (id[4] == comp.id[4]) && (id[5] == comp.id[5]);
+        return Arrays.equals(id, comp.id);
     }
 
     public boolean equals(Object o) {
@@ -37,7 +48,13 @@ public class ObjectId implements Comparable
         return this.equals(comp);
     }
 
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(id);
+    }
+
     /** Needed for putting these as keys in a TreeSet */
+    @Override
     @SuppressWarnings("ucd")
     public int compareTo(Object o) {
         ObjectId oid = (ObjectId)o;

--- a/src/projections/analysis/ObjectId.java
+++ b/src/projections/analysis/ObjectId.java
@@ -2,7 +2,7 @@ package projections.analysis;
 
 public class ObjectId implements Comparable
 {
-    private int ID_SIZE = 6;
+    private final static int ID_SIZE = 6;
     public int id[];
 
     public ObjectId() {

--- a/src/projections/analysis/StsReader.java
+++ b/src/projections/analysis/StsReader.java
@@ -393,7 +393,7 @@ public class StsReader extends ProjDefs
     	return getEntryChareNameByIndex(index) + "::" + getEntryNameByIndex(index);
     }   
     
-	public Integer getEntryIndex(Integer ID) {
+	public Integer getEntryIndex(int ID) {
 		if(ID<0)
     		return ID;
 		return entryIDToFlat.get(ID);

--- a/src/projections/analysis/TimelineEvent.java
+++ b/src/projections/analysis/TimelineEvent.java
@@ -9,7 +9,6 @@ import projections.misc.MiscUtil;
 /** A class that represents an event from the log, Eventually an EntryMethod object or UserEventObject will be created from this data */
 public class TimelineEvent implements Comparable
 {
- 
 public long BeginTime;
 public long EndTime;
 public long RecvTime;

--- a/src/projections/analysis/TimelineEvent.java
+++ b/src/projections/analysis/TimelineEvent.java
@@ -66,7 +66,7 @@ public long RecvTime;
 	EntryPoint=ep; SrcPe=pe; MsgLen=mlen;
         RecvTime = r;
 
-	id = new ObjectId(d);
+	id = ObjectId.createObjectId(d);
 	EventID = eventid;
 	this.numPapiCounts = numPapiCounts;
 	this.papiCounts = papiCounts;
@@ -85,7 +85,7 @@ public long RecvTime;
 		EntryPoint=ep; SrcPe=pe; MsgLen=mlen;
 		RecvTime = r;
 
-		id = new ObjectId(d);
+		id = ObjectId.createObjectId(d);
 		EventID = eventid;
 		this.numPapiCounts = numPapiCounts;
 		this.papiCounts = papiCounts;

--- a/src/projections/gui/ChooseEntriesWindow.java
+++ b/src/projections/gui/ChooseEntriesWindow.java
@@ -1,7 +1,6 @@
 package projections.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -15,7 +14,6 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumn;
 
 import projections.Tools.Timeline.Data;
@@ -68,8 +66,8 @@ public class ChooseEntriesWindow extends JFrame
 	
 	private void addIdleOverhead() {
 		if (data!= null && data.handleIdleOverhead() || data==null) {
-			entryNames.put(Analysis.isOverhead, "Overhead");
-			entryNames.put(Analysis.isIdle, "Idle");
+			entryNames.put(Analysis.OVERHEAD_ENTRY_POINT, "Overhead");
+			entryNames.put(Analysis.IDLE_ENTRY_POINT, "Idle");
 		}
 	}
 


### PR DESCRIPTION
Various optimizations mostly aimed toward saving memory and improving performance when using Timeline. For the test case of Frontera NAMD logs I've been using, VisualVM reports that this branch results in a ~40% smaller total heap size (from 1,124 MB to 666 MB for the fairly small test case, I expect a better percentage savings for bigger logs since there is a significant fixed size component).

There are several other similar optimizations that can be made to other parts of Projections, this PR focuses on just the Timeline hot path lest it become too big.