### PR TITLE
Fix Timeline boundary rendering

### DIFF
--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -850,7 +850,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 			leftCoord = data.timeToScreenPixelLeft(data.startTime(), actualDisplayWidth);
 
 		// Determine the coordinates and sizes of the components of the graphical representation of the object
-		int rectWidth = Math.max(1, rightCoord - leftCoord + 1);
+		int rectWidth = Math.max(1, rightCoord - leftCoord);
 		int rectHeight = data.barheight();
 
 		int left  = leftCoord;

--- a/src/projections/Tools/Timeline/MainPanel.java
+++ b/src/projections/Tools/Timeline/MainPanel.java
@@ -214,11 +214,13 @@ public class MainPanel extends JPanel  implements Scrollable, MouseListener, Mou
 	 */
 	public class MaxFilledX {
 		public int ep, pack, msg;
+		public boolean epIsIdle;
 
 		public MaxFilledX() {
 			ep = 0;
 			pack = 0;
 			msg = 0;
+			epIsIdle = false;
 		}
 	}
 	/**


### PR DESCRIPTION
Fixes issues where blocks would overlap with each other or where idle blocks would hide active blocks.