### PR TITLE
Fix parsing of " followed by a space in sts file

### DIFF
--- a/src/projections/analysis/StsReader.java
+++ b/src/projections/analysis/StsReader.java
@@ -123,7 +123,7 @@ public class StsReader extends ProjDefs
         }
 
         // If it starts and ends with a quote, then we've already matched
-        if (current.endsWith("\"")) {
+        if (current.endsWith("\"") && current.length() >= 2) {
             return current.substring(1, current.length() - 1);
         }
 


### PR DESCRIPTION
When there is a space after the opening double quote of a quoted section, after tokenization, it became a single character string that the erroneous parsing code thought both began and ended the quoted section. Ensuring the string is at least two characters long fixes this.