### PR TITLE
Hash entry method ID to select default colors

### DIFF
--- a/src/projections/Tools/Timeline/EntryMethodObject.java
+++ b/src/projections/Tools/Timeline/EntryMethodObject.java
@@ -25,6 +25,7 @@ import projections.analysis.Analysis;
 import projections.analysis.ObjectId;
 import projections.analysis.PackTime;
 import projections.analysis.TimelineEvent;
+import projections.gui.ColorManager;
 import projections.gui.MainWindow;
 import projections.gui.U;
 import projections.misc.MiscUtil;
@@ -1063,21 +1064,7 @@ class EntryMethodObject implements Comparable, Range1D, ActionListener, MainPane
 				color += (extraFields.memoryUsage * 6121) % 5953;
 			}
 
-			 // Should range from 0.0 to 2.0
-			 float h2 = ((color+512) % 512) / 256.0f;
-			 // Should range from 0.0 to 1.0
-			 float h = ((color+512) % 512) / 512.0f;
-
-			
-			
-			float s = 1.0f;   // Should be 1.0
-
-			float b = 1.0f;   // Should be 0.5 or 1.0
-
-			if(h2 > 1.0)
-				b = 0.6f;
-
-			colToSave = Color.getHSBColor(h, s, b);
+			colToSave = ColorManager.createFromLong(color);
 
 		}
 		if (colToSave == null) {

--- a/src/projections/gui/ColorManager.java
+++ b/src/projections/gui/ColorManager.java
@@ -193,20 +193,25 @@ public class ColorManager
 //		}
 //	}
 
-	
-	
 	public static Color[] createColorMap(int numColors) {
 		Color[] colors = new Color[numColors];
-		float H = (float)1.0;
-		float S = (float)1.0;
-		float B = (float)1.0;
-		float delta = (float)(1.0/numColors);
-		for(int i=0; i<numColors; i++) {
-			colors[i] = Color.getHSBColor(H, S, B);
-			H -= delta;
-			if(H < 0.0) { H = (float)1.0; }
+		for (int i = 0; i < numColors; i++) {
+			colors[i] = createFromLong((i * 251) % 5113);
 		}
 		return colors;
+	}
+
+	public static Color createFromLong(long color) {
+		// Should range from 0.0 to 1.0
+		final float H = (color * 29 % 512) / 512.0f;
+
+		float S = (color % 1536) / 512.0f;
+		S = (S < 1.0) ? 0.7f : 1.0f;
+
+		float B = (color % 1536) / 512.0f;
+		B = (B < 2.0) ? 1.0f : 0.6f;
+
+		return Color.getHSBColor(H, S, B);
 	}
 	
 	public static Color[] createComplementaryColorMap(int numUserEntries) {


### PR DESCRIPTION
Previously, the default color mapping used in most tools resulted in
consecutive entry methods having very similar colors. Now, it uses a
hash of the entry method ID, resulting in an increased likelihood of
perceptible difference between consecutive entry methods.
