### PR TITLE
CODEOWNERS: Restore matthiasdiener, add ericjbohm as co-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ritvikrao @lvkale
+* @ritvikrao @lvkale @matthiasdiener @ericjbohm


### PR DESCRIPTION
The #153 squash fixed the CODEOWNERS format but dropped matthiasdiener, who continues to contribute and review. This restores him and adds ericjbohm, a regular reviewer. All four handles share one line, so each is a code owner (with separate lines, only the last line counts).