### PR TITLE
CommOverTime: Add average message size line views

### DIFF
--- a/src/projections/Tools/CommunicationOverTime/CommTimeWindow.java
+++ b/src/projections/Tools/CommunicationOverTime/CommTimeWindow.java
@@ -5,11 +5,16 @@ import java.awt.Cursor;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Paint;
+import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -19,10 +24,13 @@ import projections.analysis.TimedProgressThreadExecutor;
 import projections.gui.GenericGraphColorer;
 import projections.gui.GenericGraphWindow;
 import projections.gui.IntervalChooserPanel;
+import projections.gui.Legend;
 import projections.gui.MainWindow;
 import projections.gui.RangeDialog;
 import projections.gui.U;
 import projections.gui.Util;
+import projections.gui.graph.Graph;
+import projections.gui.graph.YAxis;
 
 
 public class CommTimeWindow extends GenericGraphWindow
@@ -63,6 +71,21 @@ implements ActionListener
 
     private JRadioButton receivedExternalNodeMsgs;
 	private JRadioButton receivedExternalNodeBytes;
+
+	private JRadioButton avgSizeSent;
+	private JRadioButton avgSizeReceived;
+	private JRadioButton avgSizeExternal;
+	private JRadioButton avgSizeExternalNode;
+
+	private JCheckBox showLegendCheckBox;
+	private Legend legendWindow;
+	private static final int LEGEND_TOP_N = 10;
+	// avg-size views show at most this many EPs (largest total bytes first),
+	// so the chart and its legend stay 1:1 and readable
+	private static final int AVG_SIZE_MAX_LINES = 10;
+	// EPs with messages in fewer intervals than this are outliers (e.g. one
+	// giant message in a single interval) and are left off the avg-size chart
+	private static final int AVG_SIZE_MIN_INTERVALS = 2;
 
 	private ButtonGroup yScaleGroup;
 	private JRadioButton totalsButton;
@@ -110,10 +133,24 @@ implements ActionListener
 	private double[][]     receivedExternalNodeMsgOutput;
 	private double[][]     receivedExternalNodeByteOutput;
 
+	// avg-size line view state: column k of avgSizeOutput is EP avgSizeEPMap[k];
+	// only the top AVG_SIZE_MAX_LINES EPs by total bytes get a column
+	private boolean        inAvgSizeMode;
+	private double[][]     avgSizeOutput;
+	private int[]          avgSizeEPMap;
+	private double[][]     avgSizeMsgSource;
+	private double[][]     avgSizeByteSource;
+	private int            avgSizeOmittedEPs;
+	// colors to restore when leaving avg-size mode (which forces a white
+	// background so the thin colored lines stay readable)
+	private java.awt.Color savedBackground;
+	private java.awt.Color savedForeground;
+
 	// format for output
 	private DecimalFormat  _format;
 
 	private MyColorer commTimeColors;
+	private AvgSizeColorer avgSizeColors;
 
 	public CommTimeWindow(MainWindow mainWindow) {
 		super("Projections Communication vs Time Graph - " + MainWindow.runObject[myRun].getFilename() + ".sts", mainWindow);
@@ -124,6 +161,7 @@ implements ActionListener
 		stateArray = new boolean[numEPs];
 //		existsArray = new boolean[numEPs];
 		commTimeColors = new MyColorer();
+		avgSizeColors = new AvgSizeColorer();
 		entryNames = new String[numEPs];
 		for (int ep=0; ep<numEPs; ep++) {
 			entryNames[ep] = MainWindow.runObject[myRun].getEntryNameByIndex(ep);
@@ -166,8 +204,44 @@ implements ActionListener
 			return outColors;
 		}
 	}
-	
-	
+
+	/** Y axis for the avg-size views: the data is log2(bytes+1), so integer
+	 *  ticks are powers of two and get labeled with the actual size
+	 *  (2, 4, ... 512, 1K, 2K, ... 1M ...). */
+	private static class Log2BytesYAxis extends YAxis {
+		private final String title;
+		private final double max;
+		Log2BytesYAxis(String title, double max) {
+			this.title = title;
+			this.max = max;
+		}
+		public String getTitle() { return title; }
+		public double getMax() { return max; }
+		public String getValueName(double value) {
+			int v = (int) Math.round(value);
+			if (v >= 30) return (1L << (v-30)) + "G";
+			if (v >= 20) return (1L << (v-20)) + "M";
+			if (v >= 10) return (1L << (v-10)) + "K";
+			return String.valueOf(1L << v);
+		}
+	}
+
+	/** Colors for the avg-size line view, whose columns are the filtered EP set */
+	public class AvgSizeColorer implements GenericGraphColorer {
+
+		public Paint[] getColorMap() {
+			if (avgSizeEPMap == null) {
+				return new Paint[0];
+			}
+			Paint[] outColors = new Paint[avgSizeEPMap.length];
+			for (int k=0; k<avgSizeEPMap.length; k++) {
+				outColors[k] = MainWindow.runObject[myRun].getEntryColor(avgSizeEPMap[k]);
+			}
+			return outColors;
+		}
+	}
+
+
 	protected void createMenus(){
 		super.createMenus();
 	}
@@ -204,6 +278,19 @@ implements ActionListener
 		receivedExternalNodeBytes.addActionListener(this);
 		receivedExternalNodeBytes.setToolTipText("Number of bytes received from a different process");
 
+		avgSizeSent = new JRadioButton("Avg Size Sent");
+		avgSizeSent.addActionListener(this);
+		avgSizeSent.setToolTipText("Average size (bytes/message) of messages sent, one line per entry method; intervals with no messages plot as 0");
+		avgSizeReceived = new JRadioButton("Avg Size Recv");
+		avgSizeReceived.addActionListener(this);
+		avgSizeReceived.setToolTipText("Average size (bytes/message) of messages received, one line per entry method; intervals with no messages plot as 0");
+		avgSizeExternal = new JRadioButton("Avg Size External Recv");
+		avgSizeExternal.addActionListener(this);
+		avgSizeExternal.setToolTipText("Average size (bytes/message) of messages received from a different PE, one line per entry method");
+		avgSizeExternalNode = new JRadioButton("Avg Size External Node Recv");
+		avgSizeExternalNode.addActionListener(this);
+		avgSizeExternalNode.setToolTipText("Average size (bytes/message) of messages received from a different process, one line per entry method");
+
 		btg = new ButtonGroup();
 		btg.add(sentMsgs);
 		btg.add(sentBytes);
@@ -213,6 +300,10 @@ implements ActionListener
 		btg.add(receivedExternalBytes);
 		btg.add(receivedExternalNodeMsgs);
 		btg.add(receivedExternalNodeBytes);
+		btg.add(avgSizeSent);
+		btg.add(avgSizeReceived);
+		btg.add(avgSizeExternal);
+		btg.add(avgSizeExternalNode);
 
 		viewSelectPanel = new JPanel();
 		Util.gblAdd(viewSelectPanel, sentMsgs, gbc, 0,0, 1,1, 1,1);
@@ -223,6 +314,10 @@ implements ActionListener
 		Util.gblAdd(viewSelectPanel, receivedExternalBytes, gbc, 5,0, 1,1, 1,1);
 		Util.gblAdd(viewSelectPanel, receivedExternalNodeMsgs, gbc, 6,0, 1,1, 1,1);
 		Util.gblAdd(viewSelectPanel, receivedExternalNodeBytes, gbc, 7,0, 1,1, 1,1);
+		Util.gblAdd(viewSelectPanel, avgSizeSent, gbc, 0,1, 2,1, 1,1);
+		Util.gblAdd(viewSelectPanel, avgSizeReceived, gbc, 2,1, 2,1, 1,1);
+		Util.gblAdd(viewSelectPanel, avgSizeExternal, gbc, 4,1, 2,1, 1,1);
+		Util.gblAdd(viewSelectPanel, avgSizeExternalNode, gbc, 6,1, 2,1, 1,1);
 
 		totalsButton = new JRadioButton("Totals per interval", true);
 		totalsButton.addActionListener(this);
@@ -250,6 +345,9 @@ implements ActionListener
 		setRanges.addActionListener(this);
 
 		totalCount = new JLabel();
+		showLegendCheckBox = new JCheckBox("Show Legend");
+		showLegendCheckBox.setToolTipText("Movable window naming the displayed entry methods; opens automatically for the Avg Size line views, where hover popups are unavailable");
+		showLegendCheckBox.addActionListener(this);
 		//	epSelection = new JButton("Select Entry Points");
 		//	epSelection.addActionListener(this);
 		controlPanel = new JPanel();
@@ -257,6 +355,7 @@ implements ActionListener
 		//	Util.gblAdd(controlPanel, epSelection, gbc, 0,0, 1,1, 0,0);
 		Util.gblAdd(controlPanel, setRanges,   gbc, 0,0, 1,1, 0,0);
 		Util.gblAdd(controlPanel, totalCount,   gbc, 1,0, 1,1, 0,0);
+		Util.gblAdd(controlPanel, showLegendCheckBox, gbc, 2,0, 1,1, 0,0);
 
 		graphPanel = getMainPanel();
 		Util.gblAdd(mainPanel, graphPanel,     gbc, 0,1, 1,1, 1,1);
@@ -320,6 +419,39 @@ implements ActionListener
 	}
 
 	public void changeView(JRadioButton cb) {
+		boolean avgMode = (cb == avgSizeSent) || (cb == avgSizeReceived)
+				|| (cb == avgSizeExternal) || (cb == avgSizeExternalNode);
+		// Averages are not additive, so the avg-size views use unstacked lines
+		// (one per EP) instead of stacked bars, and the rate scalings (which
+		// would divide an already-normalized ratio) are disabled.
+		totalsButton.setEnabled(!avgMode);
+		rateButton.setEnabled(!avgMode);
+		ratePerPEButton.setEnabled(!avgMode);
+		if (avgMode != inAvgSizeMode && getGraphPanel() != null) {
+			if (avgMode) {
+				getGraphPanel().selectGraphType(Graph.LINE, false);
+				graphCanvas.setHorizontalGridlines(true);
+				// thin colored lines are hard to read on the default black
+				// background: force white while in avg-size mode
+				savedBackground = MainWindow.runObject[myRun].background;
+				savedForeground = MainWindow.runObject[myRun].foreground;
+				MainWindow.runObject[myRun].background = java.awt.Color.white;
+				MainWindow.runObject[myRun].foreground = java.awt.Color.black;
+				// line views have no hover popups, so bring up the legend
+				if (!showLegendCheckBox.isSelected()) {
+					showLegendCheckBox.setSelected(true);
+				}
+			} else {
+				getGraphPanel().selectGraphType(Graph.BAR, true);
+				graphCanvas.setHorizontalGridlines(false);
+				if (savedBackground != null) {
+					MainWindow.runObject[myRun].background = savedBackground;
+					MainWindow.runObject[myRun].foreground = savedForeground;
+				}
+			}
+		}
+		inAvgSizeMode = avgMode;
+
 		if(cb == sentMsgs) {
 			setDataSource("Messages Sent Over Time", scaleForDisplay(sentMsgOutput), 
 					commTimeColors, this);
@@ -400,6 +532,288 @@ implements ActionListener
 			totalCount.setText("Total external node bytes received: " + accumulateArray(receivedExternalNodeByteOutput));
 			super.refreshGraph();
 		}
+		else if(cb == avgSizeSent){
+			displayAvgSize("Average Sent Message Size Over Time", "avgSizeSent",
+					sentMsgCount, sentByteCount, "sent");
+		}
+		else if(cb == avgSizeReceived){
+			displayAvgSize("Average Received Message Size Over Time", "avgSizeReceived",
+					receivedMsgCount, receivedByteCount, "received");
+		}
+		else if(cb == avgSizeExternal){
+			displayAvgSize("Average External Received Message Size Over Time", "avgSizeExternal",
+					receivedExternalMsgCount, receivedExternalByteCount, "external received");
+		}
+		else if(cb == avgSizeExternalNode){
+			displayAvgSize("Average External Node Received Message Size Over Time", "avgSizeExternalNode",
+					receivedExternalNodeMsgCount, receivedExternalNodeByteCount, "external node received");
+		}
+
+		refreshLegend();
+	}
+
+	/** Show per-interval average message size as one line per entry method,
+	 *  on a log2(bytes) scale (message sizes span orders of magnitude).
+	 *  Only the AVG_SIZE_MAX_LINES EPs with the largest total byte volume are
+	 *  plotted, so the chart matches the legend 1:1. Intervals with no
+	 *  messages are NaN: the line breaks there instead of dropping to zero,
+	 *  and rare isolated messages show up as dots (see Graph.drawLineGraph). */
+	private void displayAvgSize(String title, String key, double[][] msgs, double[][] bytes, String direction) {
+		double totalMsgs = 0;
+		double totalBytes = 0;
+		double[] epMsgTotals = new double[numEPs];
+		double[] epByteTotals = new double[numEPs];
+		int[] intervalsPresent = new int[numEPs];
+		for (int ep=0; ep<numEPs; ep++) {
+			for (int interval=0; interval<numIntervals; interval++) {
+				epMsgTotals[ep] += msgs[interval][ep];
+				epByteTotals[ep] += bytes[interval][ep];
+				if (msgs[interval][ep] > 0) {
+					intervalsPresent[ep]++;
+				}
+			}
+			totalMsgs += epMsgTotals[ep];
+			totalBytes += epByteTotals[ep];
+		}
+
+		// EPs whose messages all land in a single interval are outliers
+		// (one giant message would stretch the axis); leave them off unless
+		// nothing else qualifies
+		int eligible = 0;
+		int outliers = 0;
+		for (int ep=0; ep<numEPs; ep++) {
+			if (epMsgTotals[ep] > 0) {
+				if (intervalsPresent[ep] >= AVG_SIZE_MIN_INTERVALS) {
+					eligible++;
+				} else {
+					outliers++;
+				}
+			}
+		}
+		boolean keepOutliers = (eligible == 0);
+		if (keepOutliers) {
+			eligible = outliers;
+			outliers = 0;
+		}
+
+		// keep the AVG_SIZE_MAX_LINES eligible EPs with the most total bytes
+		int outSize = Math.min(eligible, AVG_SIZE_MAX_LINES);
+		avgSizeOmittedEPs = (eligible - outSize) + outliers;
+		Integer[] byBytes = new Integer[numEPs];
+		for (int ep=0; ep<numEPs; ep++) {
+			byBytes[ep] = ep;
+		}
+		final double[] byteKey = epByteTotals;
+		java.util.Arrays.sort(byBytes, new Comparator<Integer>() {
+			public int compare(Integer a, Integer b) {
+				return Double.compare(byteKey[b], byteKey[a]);
+			}
+		});
+		avgSizeEPMap = new int[outSize];
+		int count = 0;
+		for (int i=0; i<numEPs && count<outSize; i++) {
+			int ep = byBytes[i];
+			if (epMsgTotals[ep] > 0
+					&& (keepOutliers || intervalsPresent[ep] >= AVG_SIZE_MIN_INTERVALS)) {
+				avgSizeEPMap[count++] = ep;
+			}
+		}
+		// EP index order, so column order matches the other views
+		java.util.Arrays.sort(avgSizeEPMap);
+
+		double maxLog = 1;
+		avgSizeOutput = new double[numIntervals][outSize];
+		for (int k=0; k<outSize; k++) {
+			int ep = avgSizeEPMap[k];
+			for (int interval=0; interval<numIntervals; interval++) {
+				double m = msgs[interval][ep];
+				// log2(avg+1) keeps zero-length messages at y=0; NaN = no data
+				if (m > 0) {
+					double v = Math.log(bytes[interval][ep]/m + 1.0) / Math.log(2.0);
+					avgSizeOutput[interval][k] = v;
+					if (v > maxLog) {
+						maxLog = v;
+					}
+				} else {
+					avgSizeOutput[interval][k] = Double.NaN;
+				}
+			}
+		}
+		avgSizeMsgSource = msgs;
+		avgSizeByteSource = bytes;
+
+		setDataSource(title, avgSizeOutput, avgSizeColors, this);
+		setPopupText(key);
+		setXAxis("Time (" + U.humanReadableString(intervalSize) + " resolution)", "Time",
+				startInterval*intervalSize, intervalSize);
+		// ticks are labeled with actual sizes (2, 4, ... 1K, 2K, ... 1M)
+		setYAxis(new Log2BytesYAxis("Avg Message Size (log scale)", Math.ceil(maxLog)));
+		if (totalMsgs > 0) {
+			String note = "";
+			if (avgSizeOmittedEPs > 0) {
+				note = "; showing top " + outSize + " EPs by bytes, " + avgSizeOmittedEPs + " omitted";
+				if (outliers > 0) {
+					note += " (" + outliers + " single-interval)";
+				}
+			}
+			totalCount.setText("Overall average " + direction + " message size: "
+					+ formatBytes(totalBytes/totalMsgs) + " over " + Math.round(totalMsgs)
+					+ " messages" + note);
+		} else {
+			totalCount.setText("No " + direction + " messages in the selected range");
+		}
+		super.refreshGraph();
+	}
+
+	private String formatBytes(double bytes) {
+		if (bytes >= 1024.0*1024.0) {
+			return _format.format(bytes/(1024.0*1024.0)) + " MB";
+		}
+		if (bytes >= 1024.0) {
+			return _format.format(bytes/1024.0) + " KB";
+		}
+		return _format.format(bytes) + " B";
+	}
+
+	private void refreshLegend() {
+		if (showLegendCheckBox != null && showLegendCheckBox.isSelected()) {
+			showLegendWindow();
+		} else {
+			closeLegendWindow();
+		}
+	}
+
+	/** Open (or refresh) the movable legend for the current view. */
+	private void showLegendWindow() {
+		Point oldLocation = null;
+		if (legendWindow != null) {
+			Legend l = legendWindow;
+			legendWindow = null;
+			oldLocation = l.getFrame().getLocation();
+			l.dispose();
+		}
+		legendWindow = makeLegend();
+		if (legendWindow == null) {
+			showLegendCheckBox.setSelected(false);
+			return;
+		}
+		if (oldLocation != null) {
+			legendWindow.getFrame().setLocation(oldLocation);
+		} else {
+			legendWindow.getFrame().setLocationRelativeTo(thisWindow);
+		}
+		// Keep the checkbox in sync if the user closes the legend window directly
+		legendWindow.getFrame().addWindowListener(new java.awt.event.WindowAdapter() {
+			public void windowClosing(java.awt.event.WindowEvent e) {
+				legendWindow = null;
+				showLegendCheckBox.setSelected(false);
+			}
+		});
+	}
+
+	private void closeLegendWindow() {
+		if (legendWindow != null) {
+			Legend l = legendWindow;
+			legendWindow = null;
+			l.dispose();
+		}
+	}
+
+	/** One legend entry with its sorting value */
+	private static class LegendEntry {
+		final double value;
+		final String label;
+		final Paint paint;
+		LegendEntry(double value, String label, Paint paint) {
+			this.value = value;
+			this.label = label;
+			this.paint = paint;
+		}
+	}
+
+	/** Build a legend for the current view: every displayed EP for the
+	 *  avg-size line views (labeled with its overall average size), the
+	 *  top-{@value #LEGEND_TOP_N} EPs by total for the bar views. */
+	private Legend makeLegend() {
+		List<LegendEntry> entries = new ArrayList<LegendEntry>();
+		String title;
+
+		if (inAvgSizeMode) {
+			if (avgSizeEPMap == null || avgSizeMsgSource == null) {
+				return null;
+			}
+			title = (avgSizeOmittedEPs > 0)
+					? "Avg Msg Size (top " + avgSizeEPMap.length + " EPs by bytes)"
+					: "Avg Msg Size Legend";
+			for (int k=0; k<avgSizeEPMap.length; k++) {
+				int ep = avgSizeEPMap[k];
+				double m = 0;
+				double b = 0;
+				for (int interval=0; interval<numIntervals; interval++) {
+					m += avgSizeMsgSource[interval][ep];
+					b += avgSizeByteSource[interval][ep];
+				}
+				double avg = (m > 0) ? b/m : 0;
+				entries.add(new LegendEntry(avg,
+						formatBytes(avg) + " (" + Math.round(m) + " msgs)  "
+						+ MainWindow.runObject[myRun].getPrettyEntryNameByIndex(ep),
+						MainWindow.runObject[myRun].getEntryColor(ep)));
+			}
+		} else {
+			double[][] data = currentOutputArray();
+			if (data == null) {
+				return null;
+			}
+			boolean isBytes = currentArrayName != null && currentArrayName.contains("Byte");
+			title = "Legend (top " + LEGEND_TOP_N + ")";
+			for (int ep=0; ep<numEPs; ep++) {
+				double total = 0;
+				for (int interval=0; interval<numIntervals; interval++) {
+					total += data[interval][ep];
+				}
+				if (total > 0) {
+					String amount = isBytes ? formatBytes(total) : Math.round(total) + " msgs";
+					entries.add(new LegendEntry(total,
+							amount + "  " + MainWindow.runObject[myRun].getPrettyEntryNameByIndex(ep),
+							MainWindow.runObject[myRun].getEntryColor(ep)));
+				}
+			}
+		}
+
+		// largest first, so the legend reads top-down like the biggest lines/bars
+		Collections.sort(entries, new Comparator<LegendEntry>() {
+			public int compare(LegendEntry a, LegendEntry b) {
+				return Double.compare(b.value, a.value);
+			}
+		});
+		int max = inAvgSizeMode ? entries.size() : Math.min(entries.size(), LEGEND_TOP_N);
+
+		List<String> names = new ArrayList<String>();
+		List<Paint> paints = new ArrayList<Paint>();
+		for (int i=0; i<max; i++) {
+			names.add(entries.get(i).label);
+			paints.add(entries.get(i).paint);
+		}
+		if (names.isEmpty()) {
+			return null;
+		}
+		return new Legend(title, names, paints);
+	}
+
+	/** The raw per-interval array backing the currently selected bar view */
+	private double[][] currentOutputArray() {
+		if (currentArrayName == null) {
+			return null;
+		}
+		if (currentArrayName.equals("sentMsgCount")) return sentMsgOutput;
+		if (currentArrayName.equals("sentByteCount")) return sentByteOutput;
+		if (currentArrayName.equals("receivedMsgCount")) return receivedMsgOutput;
+		if (currentArrayName.equals("receivedByteCount")) return receivedByteOutput;
+		if (currentArrayName.equals("receivedExternalMsgCount")) return receivedExternalMsgOutput;
+		if (currentArrayName.equals("receivedExternalByteCount")) return receivedExternalByteOutput;
+		if (currentArrayName.equals("receivedExternalNodeMsgCount")) return receivedExternalNodeMsgOutput;
+		if (currentArrayName.equals("receivedExternalNodeByteCount")) return receivedExternalNodeByteOutput;
+		return null;
 	}
 
 	protected void setGraphSpecificData(){
@@ -572,6 +986,27 @@ implements ActionListener
 		if( (xVal < 0) || (yVal <0) || currentArrayName==null)
 			return null;
 
+		// avg-size views: yVal indexes the filtered EP columns, not stateArray.
+		// (Line graphs currently never fire popups; this is here in case they do.)
+		if (currentArrayName.startsWith("avgSize")) {
+			if (avgSizeEPMap == null || yVal >= avgSizeEPMap.length || xVal >= numIntervals) {
+				return null;
+			}
+			int ep = avgSizeEPMap[yVal];
+			String[] avgString = new String[4];
+			avgString[0] = "Time Interval: " +
+			U.humanReadableString((xVal+startInterval)*intervalSize) + " to " +
+			U.humanReadableString((xVal+startInterval+1)*intervalSize);
+			avgString[1] = "Dest. Chare: " + MainWindow.runObject[myRun].getEntryChareNameByIndex(ep);
+			avgString[2] = "Dest. EPid: " + MainWindow.runObject[myRun].getEntryNameByIndex(ep);
+			double m = avgSizeMsgSource[xVal][ep];
+			avgString[3] = (m > 0)
+					? "Avg size: " + formatBytes(avgSizeByteSource[xVal][ep]/m) +
+					" over " + Math.round(m) + " messages"
+					: "No messages in this interval";
+			return avgString;
+		}
+
 		// find the ep corresponding to the yVal
 		int count = 0;
 		String epName = "";
@@ -657,6 +1092,8 @@ implements ActionListener
 				showDialog();
 			}
 			
+		} else if (e.getSource() == showLegendCheckBox) {
+			refreshLegend();
 		} else if (e.getSource() instanceof JMenuItem) {
 			String arg = ((JMenuItem)e.getSource()).getText();
 			if (arg.equals("Close")) {

--- a/src/projections/gui/GenericGraphWindow.java
+++ b/src/projections/gui/GenericGraphWindow.java
@@ -141,6 +141,12 @@ implements PopUpAble, ColorUpdateNotifier
 		return mainPanel;
 	}
 
+	/** The panel wrapping the graph canvas, for tools that need to switch
+	 *  graph type programmatically (see GraphPanel.selectGraphType). */
+	protected GraphPanel getGraphPanel(){
+		return graphPanel;
+	}
+
 
 	protected void setXAxis(String title,String units){
 		xAxis = new XAxisFixed(title,units);
@@ -181,7 +187,14 @@ implements PopUpAble, ColorUpdateNotifier
 			yAxis = new YAxisAuto(title,units,dataSource);
 		else
 			// create a dummy YAxis storing the title and units
-			yAxis = new YAxisFixed(title,units,0);	
+			yAxis = new YAxisFixed(title,units,0);
+	}
+
+	/** Install a fully custom y-axis (e.g. transformed scales whose tick
+	 *  labels are not the raw data values). Call after setDataSource, which
+	 *  would otherwise replace the axis with a YAxisAuto. */
+	protected void setYAxis(YAxis axis){
+		yAxis = axis;
 	}
 	
 		

--- a/src/projections/gui/graph/Graph.java
+++ b/src/projections/gui/graph/Graph.java
@@ -36,16 +36,17 @@ public class Graph extends JPanel
 
 //    public static final int STACKED   = 0;  // type of the bar graph
 //    public static final int UNSTACKED = 1;  // single, multiple or stacked
-    protected static final int AREA      = 2;  // Area graph (stacked)
+    public static final int AREA      = 2;  // Area graph (stacked)
 //    public static final int SINGLE    = 3;  // take the average of all y-values
-    protected static final int BAR       = 4;  // Graph type, bar graph
-    protected static final int LINE      = 5;  // or line graph
+    public static final int BAR       = 4;  // Graph type, bar graph
+    public static final int LINE      = 5;  // or line graph
 
     private static final int X_AXIS = 0;
     private static final int Y_AXIS = 1;
     
     private int GraphType;
     private boolean GraphStacked;
+    private boolean showHorizontalGridlines = false;
     private DataSource dataSource;
     private XAxis xAxis;
     private YAxis yAxis;
@@ -208,6 +209,13 @@ public class Graph extends JPanel
 	return GraphType;
     }
 
+    /** Draw light horizontal gridlines across the plot at every other
+     *  y-axis tick (helpful for sparse line graphs). Off by default. */
+    public void setHorizontalGridlines(boolean isSet)
+    {
+	showHorizontalGridlines = isSet;
+    }
+
     public void setStackGraph(boolean isSet)
     {
 	GraphStacked = isSet;
@@ -312,8 +320,14 @@ public class Graph extends JPanel
     			} else{
     				return whichBar;
     			}
-    		} 
-    	}	
+    		} else if (GraphType == LINE) {
+    			// line samples sit at interval centers; the nearest one is fine
+    			if (dataSource != null && whichBar >= 0 &&
+    					whichBar < dataSource.getIndexCount()) {
+    				return whichBar;
+    			}
+    		}
+    	}
     	return -1;
     }
 	
@@ -327,9 +341,36 @@ public class Graph extends JPanel
      *  Hence, the array looping code is adequate for now.
      */
     private int getYValue(int xVal, int yPos) {
+    	if ((GraphType == LINE) && !GraphStacked) {
+    		// unstacked lines: pick the series whose sample at xVal is
+    		// closest to the mouse, within a small pixel tolerance
+    		if ( (xVal >= 0) &&
+    				(yPos < originY()) && (yPos > topMargin()) &&
+    				(dataSource != null) &&
+    				(xVal < dataSource.getIndexCount()) ) {
+    			int numY = dataSource.getValueCount();
+    			double[] values = new double[numY];
+    			dataSource.getValues(xVal, values);
+    			int best = -1;
+    			int bestDist = 9;
+    			for (int k=0; k<numY; k++) {
+    				if (Double.isNaN(values[k])) {
+    					continue;
+    				}
+    				int y = originY() - (int)(values[k]*pixelincrementY());
+    				int dist = Math.abs(yPos - y);
+    				if (dist < bestDist) {
+    					bestDist = dist;
+    					best = k;
+    				}
+    			}
+    			return best;
+    		}
+    		return -1;
+    	}
     	if ( (xVal >= 0)  &&
-    			(yPos < originY()) && (yPos > topMargin()) && 
-    			(stackArray != null) && 
+    			(yPos < originY()) && (yPos > topMargin()) &&
+    			(stackArray != null) &&
     			(xVal < stackArray.length) ) {
     		int numY = dataSource.getValueCount();
     		int y;
@@ -339,7 +380,7 @@ public class Graph extends JPanel
     				return k;
     			}
     		}
-    	}	
+    	}
     	return -1;
     }
 
@@ -440,7 +481,9 @@ public class Graph extends JPanel
     	}
 
     	if (bubble == null && showBubble) {
-    		if (GraphStacked) {
+    		// stacked graphs, and unstacked line graphs (whose getYValue
+    		// finds the nearest series), can locate the value under the mouse
+    		if (GraphStacked || GraphType == LINE) {
     			bubble = new Bubble(this, text);
     			bubble.setLocation(xPos+offset.x, yPos+offset.y);
     			bubble.setVisible(true);
@@ -485,7 +528,12 @@ public class Graph extends JPanel
     		// Width of available chart area depends on y axis label width stored in maxLabelWidth
     		setBestIncrements(Y_AXIS, pixelincrementY(), (long)maxvalueY());
     		setBestIncrements(X_AXIS, pixelincrementX(), (int)maxvalueX());
-        	
+
+    		// gridlines go under the data
+    		if (showHorizontalGridlines) {
+    			drawYGridlines(g);
+    		}
+
     		if (GraphType == BAR) {
     			drawBarGraph(g);
     		} else if (GraphType == AREA) {
@@ -639,6 +687,22 @@ public class Graph extends JPanel
     			g.drawLine(curx, originY()+2, curx, originY());
     		}
     	}
+    }
+
+    /** Light horizontal lines at every other y tick, in a shade that stays
+     *  subtle on either background color. */
+    private void drawYGridlines(Graphics2D g) {
+    	Color background = MainWindow.runObject[myRun].background;
+    	int luminance = (background.getRed() + background.getGreen() + background.getBlue()) / 3;
+    	g.setColor(luminance > 128 ? new Color(220, 220, 220) : new Color(70, 70, 70));
+    	int tick = 0;
+    	for (long i=0; i<=maxvalueY(); i+=valuesPerTickY, tick++) {
+    		if (i > 0 && tick % 2 == 0) {
+    			int cury = originY() - (int)(i*pixelincrementY());
+    			g.drawLine(originX(), cury, originX()+availableWidth(), cury);
+    		}
+    	}
+    	g.setColor(MainWindow.runObject[myRun].foreground);
     }
 
     private void drawYAxis(Graphics2D g) {
@@ -880,31 +944,43 @@ public class Graph extends JPanel
 	// x1,y1 store previous values
 	int x1 = -1;
 	int [] y1 = new int[yValues];
+	// whether the previous interval had a value for this series;
+	// NaN values mark "no data here" and break the line into segments
+	boolean [] prevValid = new boolean[yValues];
 	// x2, y2 to store present values so that line graph can be drawn
-	int x2 = 0;		
-	int [] y2 = new int[yValues];  
+	int x2 = 0;
+	int [] y2 = new int[yValues];
 
 	for (int i=0; i<yValues; i++) {
 	    y1[i] = -1;
 	}
-	// do only till the window is reached 
-	for (int i=0; i < xValues; i++) {	
+	// do only till the window is reached
+	for (int i=0; i < xValues; i++) {
 	    if (GraphStacked) {
 		data = stackArray[i];
 	    } else {
 		dataSource.getValues(i,data);
 	    }
 	    //calculate x value
-	    x2 = originX() + (int)(i*pixelincrementX()) + 
-		(int)(pixelincrementX()/2);    
-	 
+	    x2 = originX() + (int)(i*pixelincrementX()) +
+		(int)(pixelincrementX()/2);
+
 	    for (int j=0; j<yValues; j++) {
+		if (Double.isNaN(data[j])) {
+		    prevValid[j] = false;
+		    continue;
+		}
 		g.setPaint(dataSource.getColor(j));
 		y2[j] = (originY() - (int)(data[j]*pixelincrementY()));
-		//is there any other condition that needs to be checked?
-		if(x1 != -1)	
+		if (x1 != -1 && prevValid[j]) {
 		    g.drawLine(x1,y1[j],x2,y2[j]);
-		y1[j] = y2[j];		
+		} else {
+		    // start of a segment (or an isolated sample surrounded by
+		    // gaps): mark it with a dot so it stays visible
+		    g.fillOval(x2-2, y2[j]-2, 5, 5);
+		}
+		y1[j] = y2[j];
+		prevValid[j] = true;
 	    }
 	    x1 = x2;
 	}

--- a/src/projections/gui/graph/GraphPanel.java
+++ b/src/projections/gui/graph/GraphPanel.java
@@ -66,8 +66,26 @@ public class GraphPanel extends JPanel
     public GraphPanel(Graph g)
     {
 	setBackground(Color.lightGray);
-	displayCanvas = g;		
+	displayCanvas = g;
 	createLayout();
+    }
+
+    /** Programmatically switch the graph type, keeping the type/stacked
+     *  controls at the bottom of the panel in sync. */
+    public void selectGraphType(int type, boolean stacked) {
+	if (type == Graph.LINE) {
+	    cbLineGraph.setSelected(true);
+	} else if (type == Graph.BAR) {
+	    cbBarGraph.setSelected(true);
+	} else if (type == Graph.AREA) {
+	    cbAreaGraph.setSelected(true);
+	    // area graphs are automatically stacked
+	    stacked = true;
+	}
+	cbStacked.setSelected(stacked);
+	cbStacked.setEnabled(type != Graph.AREA);
+	displayCanvas.setGraphType(type);
+	displayCanvas.setStackGraph(stacked);
     }
 
     private void createLayout() {


### PR DESCRIPTION
Adds average-message-size views to Communication Over Time, plus the line-graph infrastructure they need.

**Communication Over Time** gets a second radio row — Avg Size Sent / Recv / External Recv / External Node Recv — plotting per-interval bytes-per-message as one unstacked line per entry method (averages are not additive, so stacked bars would be wrong):

- Y values are log2(bytes) since message sizes span orders of magnitude; ticks are labeled with actual sizes (2, 4, ... 512, 1K, 2K, ... 1M).
- Only the top 10 EPs by total byte volume are plotted; EPs whose messages all fall in a single interval are omitted as outliers. The status label reports what was omitted.
- Intervals with no messages break the line rather than plotting zero; rare messages appear as dots.
- A "Show Legend" checkbox (auto-enabled entering an avg view) opens the movable Legend window listing exactly the plotted EPs with overall average size and message count. Bar views get a top-10-by-total legend.
- Avg mode forces an unstacked line chart, a white background, and horizontal gridlines, restoring previous settings on leaving. Rate scalings are disabled (bytes/message is already a ratio).

**Graph infrastructure** (reusable by other tools):

- NaN values in line data are gaps: lines break instead of dropping to zero, and isolated samples are marked with a dot.
- Hover popups now work on unstacked line graphs (nearest-series hit test).
- Optional light horizontal gridlines at every other y tick, drawn under the data.
- GraphPanel.selectGraphType() for programmatic graph-type switching with control sync; GenericGraphWindow gains getGraphPanel() and a setYAxis(YAxis) overload for custom-labeled axes.

Tested interactively on a 480-PE trace across three review rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
