### PR TITLE
Entry color choosers: search box, and only in-range entries in Time Profile

### DIFF
--- a/src/projections/Tools/TimeProfile/TimeProfileWindow.java
+++ b/src/projections/Tools/TimeProfile/TimeProfileWindow.java
@@ -23,6 +23,7 @@ import projections.analysis.LogReader;
 import projections.analysis.ProjMain;
 import projections.analysis.TimedProgressThreadExecutor;
 import projections.gui.Clickable;
+import projections.gui.EntryMethodVisibility;
 import projections.gui.GenericGraphColorer;
 import projections.gui.GenericGraphWindow;
 import projections.gui.IntervalChooserPanel;
@@ -41,7 +42,7 @@ import projections.gui.Util;
  * 
  */
 public class TimeProfileWindow extends GenericGraphWindow
-implements ActionListener, Clickable
+implements ActionListener, Clickable, EntryMethodVisibility
 {
 
 	private TimeProfileWindow thisWindow;
@@ -220,6 +221,44 @@ implements ActionListener, Clickable
 
 	}
 
+
+	/** Restrict "Choose Entry Colors" to the entry methods present in the
+	 *  loaded range (EntryMethodVisibility, consumed by ChooseEntriesWindow).
+	 *  Falls back to the full list until data has been loaded. */
+	protected EntryMethodVisibility getEntryFilter() {
+		return (graphData != null) ? this : null;
+	}
+
+	public int[] getEntriesArray() {
+		int[] present = new int[numEPs];
+		for (int ep=0; ep<numEPs; ep++) {
+			present[ep] = existsArray[ep] ? 1 : 0;
+		}
+		return present;
+	}
+
+	public boolean hasEntryList() {
+		return true;
+	}
+
+	public boolean handleIdleOverhead() {
+		return true;
+	}
+
+	public boolean entryIsVisibleID(Integer id) {
+		return true;
+	}
+
+	public void makeEntryVisibleID(Integer id) {
+		// visibility checkboxes are not shown for this tool's chooser
+	}
+
+	public void makeEntryInvisibleID(Integer id) {
+	}
+
+	public void displayMustBeRedrawn() {
+		repaint();
+	}
 
 	private static class SortableEPs implements Comparable{
 		private double value;

--- a/src/projections/Tools/Timeline/ChooseUserEventsWindow.java
+++ b/src/projections/Tools/Timeline/ChooseUserEventsWindow.java
@@ -1,18 +1,26 @@
 package projections.Tools.Timeline;
 
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Vector;
+import java.util.regex.Pattern;
 
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.RowFilter;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
 
 class ChooseUserEventsWindow extends JFrame
 {
@@ -20,6 +28,8 @@ class ChooseUserEventsWindow extends JFrame
 	private Map<Integer, String> names;
 	private Vector<Vector> tabledata;
 	private Vector<String> columnNames;
+	private JTextField searchField;
+	private TableRowSorter<MyTableModel> sorter;
 
 	ChooseUserEventsWindow(Data _data){
 		data = _data;
@@ -78,14 +88,37 @@ class ChooseUserEventsWindow extends JFrame
 		initColumnSizes(table);
 
 		table.setDefaultRenderer(Color.class, new ColorRenderer());
-		
+
+		// row sorter used only for the search filter; column-click sorting
+		// stays off (the color column is not comparable)
+		sorter = new TableRowSorter<MyTableModel>(tableModel);
+		for (int c=0; c<tableModel.getColumnCount(); c++) {
+			sorter.setSortable(c, false);
+		}
+		table.setRowSorter(sorter);
+
+		searchField = new JTextField();
+		searchField.setToolTipText("Type part of a user event name (or ID) to filter the list");
+		searchField.getDocument().addDocumentListener(new DocumentListener() {
+			public void insertUpdate(DocumentEvent e) { updateFilter(); }
+			public void removeUpdate(DocumentEvent e) { updateFilter(); }
+			public void changedUpdate(DocumentEvent e) { updateFilter(); }
+		});
+		JPanel searchPanel = new JPanel();
+		searchPanel.setLayout(new BorderLayout());
+		searchPanel.add(new JLabel(" Search: "), BorderLayout.WEST);
+		searchPanel.add(searchField, BorderLayout.CENTER);
+
 		// put the table into a scrollpane
 		JScrollPane scroller = new JScrollPane(table);
 		scroller.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
 		// put the scrollpane into our guiRoot
-
-		this.setContentPane(scroller);
+		JPanel p = new JPanel();
+		p.setLayout(new BorderLayout());
+		p.add(searchPanel, BorderLayout.NORTH);
+		p.add(scroller, BorderLayout.CENTER);
+		this.setContentPane(p);
 
 		// Display it all
 
@@ -95,6 +128,16 @@ class ChooseUserEventsWindow extends JFrame
 
 	}
 
+
+	/** Show only rows whose user event name (or ID) contains the search text */
+	private void updateFilter() {
+		String text = searchField.getText().trim();
+		if (text.isEmpty()) {
+			sorter.setRowFilter(null);
+			return;
+		}
+		sorter.setRowFilter(RowFilter.regexFilter("(?i)" + Pattern.quote(text), 1, 2));
+	}
 
 	private void initColumnSizes(JTable table) {
 		TableColumn column = null;

--- a/src/projections/gui/ChooseEntriesWindow.java
+++ b/src/projections/gui/ChooseEntriesWindow.java
@@ -7,14 +7,21 @@ import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.RowFilter;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
 
 import projections.Tools.Timeline.Data;
 import projections.analysis.Analysis;
@@ -33,6 +40,8 @@ public class ChooseEntriesWindow extends JFrame
 	private JButton checkAll;
 	private JButton uncheckAll;
 	private JCheckBox displayAllEntryMethods;
+	private JTextField searchField;
+	private TableRowSorter<MyTableModel> sorter;
 
 	public ChooseEntriesWindow(ColorUpdateNotifier _gw) {
 		data = null;
@@ -123,6 +132,26 @@ public class ChooseEntriesWindow extends JFrame
 		table.setDefaultRenderer(ClickableColorBox.class, new ColorRenderer());
 		table.setDefaultEditor(ClickableColorBox.class, new ColorEditor());
 
+		// row sorter used only for the search filter; column-click sorting
+		// stays off (the color column is not comparable)
+		sorter = new TableRowSorter<MyTableModel>(tableModel);
+		for (int c=0; c<tableModel.getColumnCount(); c++) {
+			sorter.setSortable(c, false);
+		}
+		table.setRowSorter(sorter);
+
+		searchField = new JTextField();
+		searchField.setToolTipText("Type part of an entry method name (or ID) to filter the list");
+		searchField.getDocument().addDocumentListener(new DocumentListener() {
+			public void insertUpdate(DocumentEvent e) { updateFilter(); }
+			public void removeUpdate(DocumentEvent e) { updateFilter(); }
+			public void changedUpdate(DocumentEvent e) { updateFilter(); }
+		});
+		JPanel searchPanel = new JPanel();
+		searchPanel.setLayout(new BorderLayout());
+		searchPanel.add(new JLabel(" Search: "), BorderLayout.WEST);
+		searchPanel.add(searchField, BorderLayout.CENTER);
+
 		// put the table into a scrollpane
 		JScrollPane scroller = new JScrollPane(table);
 		scroller.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
@@ -130,6 +159,10 @@ public class ChooseEntriesWindow extends JFrame
 		// put the scrollpane into our guiRoot
 		JPanel p = new JPanel();
 		p.setLayout(new BorderLayout());
+
+		JPanel topPanel = new JPanel();
+		topPanel.setLayout(new BorderLayout());
+		topPanel.add(searchPanel, BorderLayout.SOUTH);
 
 		if (displayVisibilityCheckboxes) {
 			JPanel buttonPanel = new JPanel();
@@ -168,9 +201,10 @@ public class ChooseEntriesWindow extends JFrame
 				buttonPanel.add(displayAllEntryMethods);
 			}
 
-			p.add(buttonPanel, BorderLayout.NORTH);
+			topPanel.add(buttonPanel, BorderLayout.NORTH);
 		}
 
+		p.add(topPanel, BorderLayout.NORTH);
 		p.add(scroller, BorderLayout.CENTER);
 
 		this.setContentPane(p);
@@ -180,6 +214,18 @@ public class ChooseEntriesWindow extends JFrame
 		pack();
 		setSize(800,400);
 		setVisible(true);
+	}
+
+	/** Show only rows whose entry method name (or ID) contains the search text */
+	private void updateFilter() {
+		String text = searchField.getText().trim();
+		if (text.isEmpty()) {
+			sorter.setRowFilter(null);
+			return;
+		}
+		int nameColumn = displayVisibilityCheckboxes ? 1 : 0;
+		sorter.setRowFilter(RowFilter.regexFilter("(?i)" + Pattern.quote(text),
+				nameColumn, nameColumn+1));
 	}
 
 	public void changeVisibility(boolean visible, MyTableModel tableModel) {

--- a/src/projections/gui/GenericGraphWindow.java
+++ b/src/projections/gui/GenericGraphWindow.java
@@ -129,6 +129,13 @@ implements PopUpAble, ColorUpdateNotifier
 
 	public abstract String[] getPopup(int xVal, int yVal);
 
+	/** Subclasses may return a filter so the "Choose Entry Colors" dialog
+	 *  lists only the entry methods present in the current view (like
+	 *  Timeline's chooser); null (the default) lists all entry methods. */
+	protected EntryMethodVisibility getEntryFilter(){
+		return null;
+	}
+
 	// create a standard layout which can be called from child class or 
 	// overridden by it
 	// returns a Main Panel with vertical box layout and graphPanel attached
@@ -253,7 +260,11 @@ implements PopUpAble, ColorUpdateNotifier
 			} else if(e.getSource() == mSaveScreenshot){
 				JPanelToImage.saveToFileChooserSelection(graphCanvas, "Save Plot To File...", "ProjectionsPlot.pdf");
 			} else if (e.getSource() == mChooseColors){
-				new ChooseEntriesWindow(gw);
+				EntryMethodVisibility filter = getEntryFilter();
+				if (filter != null)
+					new ChooseEntriesWindow(filter, false, gw);
+				else
+					new ChooseEntriesWindow(gw);
 			} else if (e.getSource() == mLoadColors){
 				try {
 					MainWindow.runObject[myRun].loadColors();

--- a/src/projections/gui/MainWindow.java
+++ b/src/projections/gui/MainWindow.java
@@ -449,6 +449,10 @@ implements ScalePanel.StatusDisplay
 	}
 
 	private void updateStatusSTS(StsReader sts) {
+		if (sts == null) {
+			// trace failed to load (initAnalysis already showed the error)
+			return;
+		}
 		StringBuilder builder = new StringBuilder();
 		builder.append("<html><table>");
 		builder.append(generateInfoPanelHTML("Name", sts.getBaseName()));


### PR DESCRIPTION
Quality-of-life improvements to the entry method color/visibility choosers:

- **Search box in every chooser.** Long entry method lists are hard to scroll through when hunting for one name. The shared entry-method chooser (used by Time Profile, Timeline, Histogram, Overview, Usage Profile) and Timeline's Show/Hide User Events dialog get a Search field above the table that filters rows live as you type — case-insensitive substring match on name or ID. Clearing restores the full list; filtering composes with Timeline's "Show All Entry Methods" checkbox, and color editing stays on the correct row while filtered.
- **Time Profile's Choose Entry Colors now lists only the entry methods present in the loaded range** (plus Idle/Overhead), matching Timeline's behavior instead of showing every EP in the STS file. Implemented as a `getEntryFilter()` hook in GenericGraphWindow (default null preserves existing behavior for other tools) with TimeProfileWindow implementing `EntryMethodVisibility` backed by its existing `existsArray`.
- **MainWindow no longer NPEs when a trace fails to load** (e.g. the file was moved): the failure already shows an error dialog, but the status panel then dereferenced a null StsReader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
