### PR TITLE
Sum-detail traces: correct idle time in Time Profile and Usage Profile

### DIFF
--- a/src/projections/Tools/TimeProfile/TimeProfileWindow.java
+++ b/src/projections/Tools/TimeProfile/TimeProfileWindow.java
@@ -647,17 +647,26 @@ implements ActionListener, Clickable, EntryMethodVisibility
 
                     }
 
-					// Filter Out any bad data
+					// Filter Out any bad data. Summary traces round each EP's
+					// time within an interval, so a fully busy PE can report a
+					// few us more than the interval size, driving the derived
+					// overhead slightly negative. Clamp such small negatives to
+					// zero; only discard intervals that are out of range by more
+					// than the 5% tolerance.
+					final double tolerance = 5.0;
 					for (int interval=0; interval<graphData.length; interval++) {
 						boolean valid = true;
 						double sumForInterval = 0.0;
 						for(int e=0; e< graphData[interval].length; e++){
+							if(graphData[interval][e] < 0.0 && graphData[interval][e] >= -tolerance){
+								graphData[interval][e] = 0.0;
+							}
 							sumForInterval += graphData[interval][e];
 							if(graphData[interval][e] < 0.0){
 								valid = false;
 							}
 						}
-						if(sumForInterval > 105.0){
+						if(sumForInterval > 100.0 + tolerance){
 							valid = false;
 						}
 

--- a/src/projections/analysis/Analysis.java
+++ b/src/projections/analysis/Analysis.java
@@ -457,6 +457,25 @@ public class Analysis {
 					data[entry] += sumDetailData[interval][entry];
 				}
 			}
+
+			// sumd files carry no idle data; average the .sum files'
+			// per-interval idle percentage over the selected range.
+			// (+2 places idle at the top of the usage profile display)
+			byte idlePercentage[][] = sumAnalyzer.getIdlePercentage();
+			if (pnum >= 0 && idlePercentage != null
+					&& pnum < idlePercentage.length && idlePercentage[pnum] != null) {
+				int sumIntervalStart = (int) (begintime / getSummaryIntervalSize());
+				int sumIntervalEnd = (int) Math.ceil(endtime / (double) getSummaryIntervalSize()) - 1;
+				double idleSum = 0.0;
+				int idleCount = 0;
+				for (int i = sumIntervalStart; i <= sumIntervalEnd && i < idlePercentage[pnum].length; i++) {
+					idleSum += idlePercentage[pnum][i];
+					idleCount++;
+				}
+				if (idleCount > 0) {
+					ret[0][numUserEntries + 2] = (float) (idleSum / idleCount);
+				}
+			}
 		}
 		else if (hasSumFiles()) {
 			// The log has per-EP times across the entire execution, so use that when the whole interval is selected

--- a/src/projections/analysis/SumAnalyzer.java
+++ b/src/projections/analysis/SumAnalyzer.java
@@ -631,11 +631,11 @@ public class SumAnalyzer extends ProjDefs
 	}
 
 	public double[] getTotalIdlePercentagePerInterval(int startInterval, int endInterval) {
-		double numIntervals = endInterval - startInterval + 1;
-		double[] totalIdlePercentage = new double[(int) numIntervals];
+		int numIntervals = endInterval - startInterval + 1;
+		double[] totalIdlePercentage = new double[numIntervals];
 		for (int pe = 0; pe < nPe; pe++) {
 			for (int interval = startInterval; interval <= endInterval; interval++) {
-				totalIdlePercentage[interval - startInterval] += IdlePercentage[pe][interval] / numIntervals;
+				totalIdlePercentage[interval - startInterval] += IdlePercentage[pe][interval] / (double) nPe;
 			}
 		}
 		return totalIdlePercentage;


### PR DESCRIPTION
Three fixes for summary-detail (.sumd) traces, found while examining a 4-PE sum-detail trace whose Time Profile showed all black (overhead) and emitted "found bad data" warnings.

## Fixes

1. **SumAnalyzer: Average per-interval idle over PEs, not intervals.** `getTotalIdlePercentagePerInterval` divided each PE's idle percentage by the interval count (copied from the per-PE variant below it) instead of the PE count, making idle ~0 in every interval; Time Profile then showed the missing time as overhead — an all-black chart.

2. **Time Profile: Clamp small negative values instead of zeroing the interval.** Summary tracing rounds each EP's time within an interval, so a fully busy PE can report a few µs more than the interval size (verified against the raw .sumd data: the flagged intervals were 1001–1003 µs of work in a 1000 µs interval). The derived overhead then goes slightly negative and the bad-data filter discarded the whole interval with a log-corruption warning — for a 0.1% rounding overshoot. Negatives within the existing 5% tolerance are now clamped to zero; only genuinely out-of-range intervals are still discarded.

3. **Usage Profile: Show idle time for sum-detail traces.** The sum-detail branch of `Analysis.GetUsageData` filled only per-EP times and never set the idle slot, so bars showed no idle at all. Since .sumd files carry no idle data, it is now taken from the .sum files' per-interval idle percentage averaged over the selected range — the same source Time Profile uses.

## Testing

- `gradle copyJarToBin` + `./bin/projections --exit test/hello.sts` clean.
- On a 4-PE sum-detail trace (411 EPs, 4443 intervals): Time Profile now shows the expected idle band instead of all-black overhead, the 10 bad-data warnings are gone, and Usage Profile bars show idle segments consistent with Time Profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)