### PR TITLE
Sum-detail traces: reconcile .sum idle with .sumd entry times, and speed up bar drawing

### DIFF
--- a/src/projections/Tools/Extrema/ExtremaWindow.java
+++ b/src/projections/Tools/Extrema/ExtremaWindow.java
@@ -349,7 +349,12 @@ Clickable
 
 			// Assume that each PE has the same number of EPs
 			final int numEPs = sumDetailData_PE_EP[0].length;
-			for (int pe = 0; pe < sumDetailData_PE_EP.length; pe++) {
+			// sumDetailData_PE_EP and idleTemp are indexed by absolute PE
+			// number and cover every PE in the run, while tempData has one
+			// row per *selected* PE, in selectedPEs order (the same order
+			// peNames is built in below).
+			int peIdx = 0;
+			for (Integer pe : selectedPEs) {
 				double lis[] = new double[numEPs + 2];
 				double sum = 0.0;
 				for (int ep = 0; ep < numEPs; ep++) {
@@ -357,9 +362,15 @@ Clickable
 					sum += lis[ep];
 				}
 
-				lis[numEPs] = idleTemp[pe];
-				lis[numEPs + 1] = 100.0 - sum - lis[numEPs];
-				tempData[pe] = lis;
+				// Idle comes from the .sum files and the entry method times
+				// from the .sumd files; charm accumulates the two through
+				// independent paths and they can overlap, so give idle only
+				// what the entry methods leave free instead of deriving a
+				// negative overhead from the mismatch.
+				lis[numEPs] = Math.min(idleTemp[pe], Math.max(0.0, 100.0 - sum));
+				lis[numEPs + 1] = Math.max(0.0, 100.0 - sum - lis[numEPs]);
+				tempData[peIdx] = lis;
+				peIdx++;
 			}
 		}
 

--- a/src/projections/Tools/TimeProfile/TimeProfileWindow.java
+++ b/src/projections/Tools/TimeProfile/TimeProfileWindow.java
@@ -631,29 +631,65 @@ implements ActionListener, Clickable, EntryMethodVisibility
 					}
                     //Bilge
                     if( MainWindow.runObject[myRun].hasSumDetailFiles()){
-                        //idle time calculation for sum detail
-                        double[] idlePercentage = MainWindow.runObject[myRun].sumAnalyzer.getTotalIdlePercentagePerInterval();
+                        // Idle comes from the .sum files while the per-EP times
+                        // come from the .sumd files. Charm's trace-summary
+                        // accumulates the two through independent code paths
+                        // (see SumLogPool::add() vs updateSummaryDetail()), and
+                        // they do not always agree: an interval's per-EP times
+                        // can overlap its reported idle by several percent, and
+                        // the per-EP times alone can even exceed the interval.
+                        // The per-EP breakdown is what this chart is about, so
+                        // trust it and give idle only the time left over,
+                        // rather than deriving a negative overhead from the
+                        // mismatch and discarding the interval.
+                        // The idle array is indexed from interval 0 of the whole
+                        // run and in the .sum files' own interval size, while
+                        // graphData[0] is the selected range's first interval,
+                        // so map through absolute time rather than assuming the
+                        // two line up.
+                        // Averaged over the selected PEs only -- the entry
+                        // method percentages above are scaled by
+                        // processorList.size(), so idle has to be on the same
+                        // footing or a PE subset makes the two irreconcilable.
+                        double[] idlePercentage = MainWindow.runObject[myRun].sumAnalyzer.getTotalIdlePercentagePerInterval(processorList);
+                        long sumIntervalSize = MainWindow.runObject[myRun].getSummaryIntervalSize();
+                        int overlapCount = 0;
+                        double worstOverlap = 0.0;
                         for(int i=0;i<numIntervals;i++){
-                            graphData[i][numEPs+1] = idlePercentage[i];
-                        }
-                        //overhead time calculation for sum detail
-                        for(int i=0;i<numIntervals;i++){
-                            graphData[i][numEPs] = 100;
+                            double epTotal = 0.0;
                             for(int j=0;j<numEPs;j++){
-                                graphData[i][numEPs] -= graphData[i][j];
+                                epTotal += graphData[i][j];
                             }
-                            graphData[i][numEPs] -= graphData[i][numEPs+1];
+                            int idleIdx = (int)(((long)(startInterval + i)) * intervalSize / sumIntervalSize);
+                            double idleHere = (idleIdx >= 0 && idleIdx < idlePercentage.length)
+                                              ? idlePercentage[idleIdx] : 0.0;
+                            double overlap = epTotal + idleHere - 100.0;
+                            if(overlap > 0.0){
+                                overlapCount++;
+                                if(overlap > worstOverlap) worstOverlap = overlap;
+                            }
+                            double idle = Math.min(idleHere,
+                                                   Math.max(0.0, 100.0 - epTotal));
+                            graphData[i][numEPs+1] = idle;
+                            graphData[i][numEPs] = Math.max(0.0, 100.0 - epTotal - idle);
                         }
-
+                        if(overlapCount > 0){
+                            System.err.println("Time Profile: in " + overlapCount + " of " +
+                                numIntervals + " intervals the .sumd entry-method times and the " +
+                                ".sum idle time overlap (worst " + String.format("%.1f", worstOverlap) +
+                                "%). Idle was reduced to fit; entry-method times are unchanged.");
+                        }
                     }
 
 					// Filter Out any bad data. Summary traces round each EP's
 					// time within an interval, so a fully busy PE can report a
-					// few us more than the interval size, driving the derived
-					// overhead slightly negative. Clamp such small negatives to
+					// few us more than the interval size, driving derived
+					// values slightly negative. Clamp such small negatives to
 					// zero; only discard intervals that are out of range by more
 					// than the 5% tolerance.
 					final double tolerance = 5.0;
+					int badIntervals = 0;
+					int firstBadInterval = -1;
 					for (int interval=0; interval<graphData.length; interval++) {
 						boolean valid = true;
 						double sumForInterval = 0.0;
@@ -671,12 +707,19 @@ implements ActionListener, Clickable, EntryMethodVisibility
 						}
 
 						if(!valid){
-							System.err.println("Time Profile found bad data for interval " + interval + ". The data for bad intervals will be zero-ed out. This problem is either a log file corruption issue, or a bug in Projections.");
+							badIntervals++;
+							if(firstBadInterval < 0) firstBadInterval = interval;
 							for(int e=0; e< graphData[interval].length; e++){
 								graphData[interval][e] = 0.0;
 							}
 						}
 
+					}
+					if(badIntervals > 0){
+						System.err.println("Time Profile found bad data in " + badIntervals +
+							" of " + graphData.length + " intervals (first: " + firstBadInterval +
+							"). Those intervals were zero-ed out. This problem is either a log " +
+							"file corruption issue, or a bug in Projections.");
 					}
 					// set the exists array to accept non-zero
 					// entries only have initial state also 

--- a/src/projections/analysis/Analysis.java
+++ b/src/projections/analysis/Analysis.java
@@ -473,7 +473,16 @@ public class Analysis {
 					idleCount++;
 				}
 				if (idleCount > 0) {
-					ret[0][numUserEntries + 2] = (float) (idleSum / idleCount);
+					// The .sum idle and the .sumd per-EP times are accumulated
+					// by independent paths in charm's trace-summary and can
+					// overlap, so cap idle at whatever the entry methods leave
+					// free instead of letting the bar exceed 100%.
+					double epPercent = 0.0;
+					for (int entry = 0; entry < numUserEntries; entry++) {
+						epPercent += data[entry] * 100.0 / (endtime - begintime);
+					}
+					ret[0][numUserEntries + 2] =
+						(float) Math.min(idleSum / idleCount, Math.max(0.0, 100.0 - epPercent));
 				}
 			}
 		}

--- a/src/projections/analysis/IntervalData.java
+++ b/src/projections/analysis/IntervalData.java
@@ -3,6 +3,8 @@ package projections.analysis;
 import java.io.IOException;
 import java.util.*;
 
+import javax.swing.ProgressMonitor;
+
 import projections.analysis.SumDetailReader.RLEBlock;
 import projections.gui.MainWindow;
 
@@ -119,7 +121,22 @@ public class IntervalData
 
 		int processorCount = 0;
 
+		// Expanding the RLE data costs numPEs * numIntervals * numEPs, which
+		// runs into minutes on a large trace, so show progress the same way
+		// the .sum reader does.
+		int numPes = processorList.size();
+		ProgressMonitor progressBar =
+			new ProgressMonitor(MainWindow.runObject[myRun].guiRoot,
+					"Loading summary detail data", "", 0, numPes);
+
 		for (Integer curPe : processorList) {
+			if (progressBar.isCanceled()) {
+				progressBar.close();
+				return;
+			}
+			progressBar.setNote(processorCount + " of " + numPes + " PEs");
+			progressBar.setProgress(processorCount);
+
 			double[][] tempData = getData(curPe, TYPE_TIME, intervalSize, intervalStart, numIntervals);
 			for (int i = 0; i < numIntervals; i++) {
 				for (int ep = 0; ep < numEPs; ep++) {
@@ -134,6 +151,7 @@ public class IntervalData
 			}
 			processorCount++;
 		}
+		progressBar.close();
 	}
 
 	public int[][] getSumDetailData_interval_EP() {

--- a/src/projections/analysis/SumAnalyzer.java
+++ b/src/projections/analysis/SumAnalyzer.java
@@ -5,6 +5,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.StreamTokenizer;
 
+import java.util.SortedSet;
+
 import javax.swing.ProgressMonitor;
 
 import projections.gui.MainWindow;
@@ -628,6 +630,34 @@ public class SumAnalyzer extends ProjDefs
 
 	public double[] getTotalIdlePercentagePerInterval() {
 		return getTotalIdlePercentagePerInterval(0, IntervalCount - 1);
+	}
+
+	/** Idle percentage per interval averaged over the given processors only.
+	 *  Tools that show a subset of PEs scale their other per-interval data by
+	 *  the size of that subset, so averaging idle over every PE instead would
+	 *  put the two on different scales.
+	 */
+	public double[] getTotalIdlePercentagePerInterval(SortedSet<Integer> peList) {
+		double[] totalIdlePercentage = new double[IntervalCount];
+		if (peList == null) {
+			return totalIdlePercentage;
+		}
+		int peCount = 0;
+		for (Integer pe : peList) {
+			if (pe == null || pe < 0 || pe >= nPe || IdlePercentage[pe] == null) {
+				continue;
+			}
+			for (int interval = 0; interval < IntervalCount; interval++) {
+				totalIdlePercentage[interval] += IdlePercentage[pe][interval];
+			}
+			peCount++;
+		}
+		if (peCount > 0) {
+			for (int interval = 0; interval < IntervalCount; interval++) {
+				totalIdlePercentage[interval] /= peCount;
+			}
+		}
+		return totalIdlePercentage;
 	}
 
 	public double[] getTotalIdlePercentagePerInterval(int startInterval, int endInterval) {

--- a/src/projections/gui/graph/Graph.java
+++ b/src/projections/gui/graph/Graph.java
@@ -839,31 +839,44 @@ public class Graph extends JPanel
     	}
 
     	for (int i=0; i<numX; i++) {
+    		// Work out this bar's horizontal extent once, up front. When
+    		// there are more intervals than pixels most bars come out zero
+    		// pixels wide and draw nothing, so skip them before doing any
+    		// per-value work. Likewise skip slices that round to zero
+    		// pixels tall below. Neither changes what is drawn, but on a
+    		// trace with tens of thousands of intervals and hundreds of
+    		// EPs it removes millions of no-op fillRect calls.
+    		final int barX;
+    		final int barW;
+    		if (valuesPerTickX == 1) {
+    			barX = originX() + (int) (i * pixelincrementX() +
+    					tickIncrementX / 2 - barWidth / 2);
+    			barW = (int) barWidth;
+    		} else {
+    			barX = originX() + (int) (i * pixelincrementX());
+    			barW = (int) ((i + 1) * pixelincrementX()) -
+    					(int) (i * pixelincrementX());
+    		}
+    		if (barW <= 0) {
+    			continue;
+    		}
+
     		dataSource.getValues(i, data);
     		if (GraphStacked) {
-    			int y = 0;
     			for (int k=0; k<numY; k++) {
 			        if (data[k] > 0) {
+			        	int barH = (int) (data[k] * pixelincrementY());
+			        	if (barH <= 0) {
+			        		continue;
+			        	}
 					// calculating lowerbound of box, which StackArray
 					// allready contains
-					y = originY() - (int) (stackArray[i][k] * pixelincrementY());
+					int y = originY() - (int) (stackArray[i][k] * pixelincrementY());
 
 					g.setPaint(dataSource.getColor(k));
 
 					// using data[i] to get the height of this bar
-					if (valuesPerTickX == 1) {
-						g.fillRect(originX() + (int) (i * pixelincrementX() +
-								tickIncrementX / 2 -
-								barWidth / 2), y,
-								(int) barWidth,
-								(int) (data[k] * pixelincrementY()));
-
-					} else {
-						g.fillRect(originX() + (int) (i * pixelincrementX()), y,
-								(int) ((i + 1) * pixelincrementX()) -
-								(int) (i * pixelincrementX()),
-								(int) (data[k] * pixelincrementY()));
-					}
+					g.fillRect(barX, y, barW, barH);
 				}
     			}
     		} else {
@@ -898,20 +911,13 @@ public class Graph extends JPanel
     			}
     			// now display the graph
     			for(int k=0; k<numY; k++) {
-    				g.setPaint(dataSource.getColor((int)temp[k][0]));
-    				y = (originY()-(int)(temp[k][1]*pixelincrementY()));
-    				if (valuesPerTickX == 1) {
-    					g.fillRect(originX() + (int)(i*pixelincrementX() +
-    							tickIncrementX/2 -
-    							barWidth/2), y,
-    							(int)barWidth,
-    							(int)(temp[k][1]*pixelincrementY()));
-    				} else {				   
-    					g.fillRect(originX() + (int)(i*pixelincrementX()), y,
-    							(int)((i+1)*pixelincrementX()) -
-    							(int)(i*pixelincrementX()),
-    							(int)(temp[k][1]*pixelincrementY()));
+    				int barH = (int)(temp[k][1]*pixelincrementY());
+    				if (barH <= 0) {
+    					continue;
     				}
+    				g.setPaint(dataSource.getColor((int)temp[k][0]));
+    				y = originY() - barH;
+    				g.fillRect(barX, y, barW, barH);
     			}
     		}
     		/*  ** UNUSED for now **


### PR DESCRIPTION
Follow-on to #158, found while looking at a 1920 PE sum-detail trace (32671 intervals, 412 EPs). Three independent problems, one commit each.

### Idle vs entry method times

Time Profile stacks per-interval entry method times from the `.sumd` files against idle from the `.sum` files. charm's `trace-summary` accumulates those through independent paths (`SumLogPool::add()` / `binIdle` vs `updateSummaryDetail()`) and they do not agree, so `overhead = 100 - work - idle` came out negative. That tripped the bad-data filter for 947 intervals, zeroing them and printing 1484 "log file corruption" warnings.

Entry method times are what these charts are for, so they are now treated as authoritative and idle gets only the time they leave free. Two ways the idle series was also lined up wrongly against them are fixed:

- `getTotalIdlePercentagePerInterval()` is indexed from interval 0 of the whole run, but `graphData[0]` is the first interval of the *selected range*. Any range not starting at 0 read idle from the wrong point in time.
- Entry method percentages are divided by the number of *selected* PEs, while idle was averaged over *all* PEs, so a PE subset put the two on different scales.

Extrema's sum-detail branch had the same unguarded subtraction, plus a loop over every PE in the run writing into a `tempData` sized for the selected PEs only — an `ArrayIndexOutOfBoundsException` whenever a subset was selected, so that path only ever worked with every PE selected.

The residual disagreement is genuine rounding, 0.4–0.7% worst case on the trace above, well inside the existing 5% tolerance. Intervals that still fail the filter are now reported as one summary line rather than one per interval.

The underlying inconsistency is a charm-side bug, filed separately as charmplusplus/charm#3934.

### Bar drawing

`drawBarGraph` issued one `fillRect` per (interval, entry method) pair. With more intervals than pixels most bars are zero pixels wide, and in a stacked chart most slices round to zero pixels tall; both draw nothing. A 31000 x 412 Time Profile spent minutes on the EDT pushing ~12.8M no-op fills. Now skipped, output unchanged.

### Progress bar

The sum-detail load had no progress bar — only the `.log` path did — and its serial RLE expansion costs `numPEs * numIntervals * numEPs`, over nine billion iterations here. It looked like a hang.

### Testing

Built and smoke tested (`make test`). Verified in the GUI on the 1920 PE trace above: Time Profile over the full range and over a sub-range with every 5th PE selected, Usage Profile, and Extrema.