### PR TITLE
Overview: fix sum-detail display, add entry method coloring and time axis labels

### DIFF
--- a/src/projections/Tools/Overview/OverviewPanel.java
+++ b/src/projections/Tools/Overview/OverviewPanel.java
@@ -38,6 +38,7 @@ class OverviewPanel extends ScalePanel.Child
 	private int myRun = 0;
 
 	private int[][] entryData;   // [pe][interval]
+	private int[] entriesPresent; // [ep] 1 if the EP appears in entryData
 
 	// idleData & mergedData (for supporting - utilization for now - 
 	// the other two data formats)
@@ -377,29 +378,60 @@ class OverviewPanel extends ScalePanel.Child
 					idleDataNormalized[i][j] = (byte) (100.0f * idleData[i][j]);
 				}
 			}
+			computeEntriesPresent();
 			// We default to coloring by entry method for log files
 			colorByEntry();
 		} else if (MainWindow.runObject[myRun].hasSumDetailData()) {
 			int intervalSize = (int) MainWindow.runObject[myRun].getSumDetailIntervalSize();
-			startInterval = (int) startTime / intervalSize;
+			startInterval = (int) (startTime / intervalSize);
 			endInterval = (int) Math.ceil(((double) endTime) / intervalSize) - 1;
 			int numIntervals = endInterval - startInterval + 1;
 
-			utilizationDataNormalized = new int[selectedPEs.size()][numIntervals];
-			idleDataNormalized = new byte[selectedPEs.size()][numIntervals];
-
 			MainWindow.runObject[myRun].LoadGraphData(intervalSize, startInterval, endInterval, false, selectedPEs);
 
-			utilizationDataNormalized = MainWindow.runObject[myRun].getSumDetailData_PE_interval();
-			idleDataNormalized = MainWindow.runObject[myRun].sumAnalyzer.getIdlePercentage();
-			double scale = 100.0 / intervalSize;
+			// Both of these are indexed by position in selectedPEs and are
+			// relative to startInterval, which is what this panel displays.
+			// systemUsageData[SYS_CPU] is already a 0-100 percentage.
+			utilizationDataNormalized = MainWindow.runObject[myRun].getSystemUsageData(1);
+			entryData = MainWindow.runObject[myRun].getSumDetailData_PE_interval_maxEP();
 
-			// idleDataNormalized is already in terms of percentage, so don't convert it
-			for (int i = 0; i < utilizationDataNormalized.length; i++) {
-				for (int j = 0; j < utilizationDataNormalized[i].length - 1; j++) {
-					utilizationDataNormalized[i][j] = (int) (scale * utilizationDataNormalized[i][j]);
+			// .sumd files carry no idle data, so idle has to come from the
+			// .sum files, which are indexed by absolute PE number and binned
+			// at their own interval size.
+			idleDataNormalized = new byte[selectedPEs.size()][numIntervals];
+			byte[][] sumIdle = (MainWindow.runObject[myRun].sumAnalyzer == null) ?
+					null : MainWindow.runObject[myRun].sumAnalyzer.getIdlePercentage();
+			long sumIntervalSize = MainWindow.runObject[myRun].getSummaryIntervalSize();
+			int pIdx = 0;
+			for (Integer pe : selectedPEs) {
+				for (int j = 0; j < numIntervals; j++) {
+					int idle = 0;
+					if (sumIdle != null && pe < sumIdle.length && sumIdle[pe] != null
+							&& sumIntervalSize > 0) {
+						int sumInterval = (int)
+							((long)(startInterval + j) * intervalSize / sumIntervalSize);
+						if (sumInterval < sumIdle[pe].length) {
+							idle = sumIdle[pe][sumInterval];
+						}
+					}
+					// The .sum idle and the .sumd per-EP times are accumulated by
+					// independent paths in charm's trace-summary and can overlap,
+					// so cap idle at whatever the entry methods leave free - the
+					// same reconciliation Time Profile and Usage Profile use.
+					int util = utilizationDataNormalized[pIdx][j];
+					idleDataNormalized[pIdx][j] =
+						(byte) Math.max(0, Math.min(idle, 100 - util));
+
+					// An interval with no recorded entry method time, or one the
+					// .sum file says was mostly idle, is drawn as idle rather than
+					// getting an entry method's color.
+					if (entryData[pIdx][j] < 0 || idleDataNormalized[pIdx][j] > util) {
+						entryData[pIdx][j] = numEPs + 1;
+					}
 				}
+				pIdx++;
 			}
+			computeEntriesPresent();
 			// Color by utilization for sumdetail
 			colorByUtil();
 		} else {
@@ -409,7 +441,38 @@ class OverviewPanel extends ScalePanel.Child
 		}
 	}
 
+	/** Which entry methods actually appear in the image. The color chooser
+	 *  uses this so it offers only the colors on screen instead of every
+	 *  entry method in the run. Null if no entry method data was loaded. */
+	protected int[] getEntriesPresent() {
+		return entriesPresent;
+	}
+
+	/** Scanned once per load; ChooseEntriesWindow asks for the array
+	 *  repeatedly, and on a large trace entryData is millions of cells. */
+	private void computeEntriesPresent() {
+		if (entryData == null) {
+			entriesPresent = null;
+			return;
+		}
+		entriesPresent = new int[numEPs];
+		for (int p = 0; p < entryData.length; p++) {
+			if (entryData[p] == null)
+				continue;
+			for (int i = 0; i < entryData[p].length; i++) {
+				int ep = entryData[p][i];
+				if (ep >= 0 && ep < numEPs)
+					entriesPresent[ep] = 1;
+			}
+		}
+	}
+
 	protected void colorByEntry() {
+		if (entryData == null) {
+			// No per-entry-method data was loaded; stay in utilization mode
+			colorByUtil();
+			return;
+		}
 		mode = OverviewWindow.MODE_EP;
 		applyColorMap(entryData, true);
 	}

--- a/src/projections/Tools/Overview/OverviewWindow.java
+++ b/src/projections/Tools/Overview/OverviewWindow.java
@@ -34,15 +34,18 @@ import javax.swing.SwingWorker;
 import projections.gui.ChooseEntriesWindow;
 import projections.gui.ColorMap;
 import projections.gui.ColorUpdateNotifier;
+import projections.gui.EntryMethodVisibility;
 import projections.gui.MainWindow;
 import projections.gui.ProjectionsWindow;
 import projections.gui.RangeDialog;
 import projections.gui.ScalePanel;
 import projections.gui.ScaleSlider;
+import projections.gui.U;
 import projections.gui.Util;
 
 public class OverviewWindow extends ProjectionsWindow
-implements MouseListener, ActionListener, ScalePanel.StatusDisplay, ColorUpdateNotifier
+implements MouseListener, ActionListener, ScalePanel.StatusDisplay, ColorUpdateNotifier,
+EntryMethodVisibility
 {
 
 	// Temporary hardcode. This variable will be assigned appropriate
@@ -64,6 +67,10 @@ implements MouseListener, ActionListener, ScalePanel.StatusDisplay, ColorUpdateN
 	protected static final int MODE_EP = 1;
 
 	private ColorMap utilColorMap;
+
+	/** Time at the left edge of the display; the panel's horizontal
+	 *  coordinates are microseconds relative to it */
+	private long displayStartTime;
 
 	private OverviewWindow thisWindow;
 
@@ -117,7 +124,16 @@ implements MouseListener, ActionListener, ScalePanel.StatusDisplay, ColorUpdateN
 		gbc.fill = GridBagConstraints.BOTH;
 		Util.gblAdd(windowPane, displayPanel, gbc, 0,0, 2,1, 2,1, 1,1,1,1);
 		scalePanel.setStatusDisplay(this);
-		
+
+		// Timestamps under the horizontal tick ruler. The panel's horizontal
+		// coordinate is microseconds from the start of the displayed range,
+		// and getTicks() already follows pan and zoom.
+		scalePanel.setHorizontalAxisLabeler(new ScalePanel.AxisLabeler() {
+			public String label(double offset) {
+				return U.humanReadableString(displayStartTime + (long)offset, 3);
+			}
+		});
+
 		
 		mChooseColors = new JButton("Choose Entry Method Colors");
 		mChooseColors.addActionListener(this);
@@ -126,7 +142,9 @@ implements MouseListener, ActionListener, ScalePanel.StatusDisplay, ColorUpdateN
 		radioPanel.setLayout(new GridBagLayout());
 		Util.gblAdd(radioPanel, new JLabel("Color By:"), gbc, 0,0, 1,1, 1,1);
 
-		if(MainWindow.runObject[myRun].hasLogFiles()){
+		// Both .log files and .sumd files carry per-entry-method data
+		if(MainWindow.runObject[myRun].hasLogFiles() ||
+				MainWindow.runObject[myRun].hasSumDetailData()){
 			colorByEntryMethod = new JRadioButton("Entry Method");
 			colorByEntryMethod.setSelected(true);
 			group.add(colorByEntryMethod);
@@ -172,6 +190,7 @@ implements MouseListener, ActionListener, ScalePanel.StatusDisplay, ColorUpdateN
 
 	private void setStlPanelData(long startTime, long endTime, SortedSet<Integer> pes){
 		double horSize, verSize;
+		displayStartTime = startTime;
 		if (pes == null) {
 			horSize=MainWindow.runObject[myRun].getTotalTime();
 			verSize=MainWindow.runObject[myRun].getNumProcessors();
@@ -256,8 +275,40 @@ implements MouseListener, ActionListener, ScalePanel.StatusDisplay, ColorUpdateN
 				showDialog();
 			}
 		} else if (evt.getSource() == mChooseColors) {
-			new ChooseEntriesWindow(this);
+			new ChooseEntriesWindow(this, false, this);
 		}
+	}
+
+
+	/** Restrict "Choose Entry Method Colors" to the entry methods actually
+	 *  drawn (EntryMethodVisibility, consumed by ChooseEntriesWindow), and
+	 *  keep Idle and Overhead out of the list: this tool always draws them
+	 *  white and black, so picking colors for them would do nothing. */
+	public int[] getEntriesArray() {
+		return stl.getEntriesPresent();
+	}
+
+	public boolean hasEntryList() {
+		return stl.getEntriesPresent() != null;
+	}
+
+	public boolean handleIdleOverhead() {
+		return false;
+	}
+
+	public boolean entryIsVisibleID(Integer id) {
+		return true;
+	}
+
+	public void makeEntryVisibleID(Integer id) {
+		// visibility checkboxes are not shown for this tool's chooser
+	}
+
+	public void makeEntryInvisibleID(Integer id) {
+	}
+
+	public void displayMustBeRedrawn() {
+		repaint();
 	}
 
 	public void mouseClicked(MouseEvent evt) {
@@ -286,7 +337,8 @@ implements MouseListener, ActionListener, ScalePanel.StatusDisplay, ColorUpdateN
 
 	/** Recieve notification that colors have been changed */
 	public void colorsHaveChanged(){
-		if (colorByEntryMethod.isSelected()){
+		// colorByEntryMethod does not exist for traces without entry method data
+		if (colorByEntryMethod != null && colorByEntryMethod.isSelected()){
 			stl.colorByEntry();
 		} else{
 			stl.colorByUtil();

--- a/src/projections/analysis/Analysis.java
+++ b/src/projections/analysis/Analysis.java
@@ -367,6 +367,9 @@ public class Analysis {
 	public int[][] getSumDetailData_PE_interval() {
         return intervalData.getSumDetailData_PE_interval();
     }
+	public int[][] getSumDetailData_PE_interval_maxEP() {
+        return intervalData.getSumDetailData_PE_interval_maxEP();
+    }
 
     public Color getEntryColor(int entryIdx) {
     	if (entryIdx == IDLE_ENTRY_POINT) {

--- a/src/projections/analysis/IntervalData.java
+++ b/src/projections/analysis/IntervalData.java
@@ -62,6 +62,9 @@ public class IntervalData
     private int sumDetailData_interval_EP[][] = null;
     private int sumDetailData_PE_EP[][] = null;
     private int sumDetailData_PE_interval[][] = null;
+    // [pe list index][interval] - which EP used the most time, or -1 for none.
+    // Indexed by position in the requested processor list, like systemUsageData.
+    private int sumDetailData_PE_interval_maxEP[][] = null;
 
     /**
      *  The constructor
@@ -117,6 +120,7 @@ public class IntervalData
 		sumDetailData_interval_EP = new int[numIntervals][numEPs];
 		sumDetailData_PE_EP = new int[numPEs][numEPs];
 		sumDetailData_PE_interval = new int[numPEs][numIntervals];
+		sumDetailData_PE_interval_maxEP = new int[processorList.size()][numIntervals];
 		systemUsageData = new int[3][processorList.size()][numIntervals];
 
 		int processorCount = 0;
@@ -139,12 +143,20 @@ public class IntervalData
 
 			double[][] tempData = getData(curPe, TYPE_TIME, intervalSize, intervalStart, numIntervals);
 			for (int i = 0; i < numIntervals; i++) {
+				int maxEP = -1;
+				double maxEPTime = 0.0;
 				for (int ep = 0; ep < numEPs; ep++) {
 					sumDetailData_interval_EP[i][ep] += (int) tempData[ep][i];
 					sumDetailData_PE_EP[curPe][ep] += (int) tempData[ep][i];
 					sumDetailData_PE_interval[curPe][i] += (int) tempData[ep][i];
 					systemUsageData[1][processorCount][i] += (int) tempData[ep][i];
+					if (tempData[ep][i] > maxEPTime) {
+						maxEPTime = tempData[ep][i];
+						maxEP = ep;
+					}
 				}
+				// Overview colors each PE/interval cell by its dominant EP
+				sumDetailData_PE_interval_maxEP[processorCount][i] = maxEP;
 				// after accumulation for systemUsageData, convert to utilization percentage (0-100)
 				systemUsageData[1][processorCount][i] =
 						(int) IntervalUtils.timeToUtil(systemUsageData[1][processorCount][i], intervalSize);
@@ -164,6 +176,10 @@ public class IntervalData
 
 	public int[][] getSumDetailData_PE_interval() {
 		return sumDetailData_PE_interval;
+	}
+
+	public int[][] getSumDetailData_PE_interval_maxEP() {
+		return sumDetailData_PE_interval_maxEP;
 	}
 
     public int[][][] getSystemUsageData() {

--- a/src/projections/gui/ChooseEntriesWindow.java
+++ b/src/projections/gui/ChooseEntriesWindow.java
@@ -59,8 +59,10 @@ public class ChooseEntriesWindow extends JFrame
 
 	private void onlyEntryMethodsInRange() {
 		entryNames = new TreeMap<Integer, String>();
-		for (int i = 0; i < data.getEntriesArray().length; i++) {
-			if (MainWindow.runObject[myRun].getSts().getEntryNames().containsKey(i) && data.getEntriesArray()[i]!=0)
+		// asked for once: some tools scan their whole display to answer this
+		int[] entriesInRange = data.getEntriesArray();
+		for (int i = 0; i < entriesInRange.length; i++) {
+			if (MainWindow.runObject[myRun].getSts().getEntryNames().containsKey(i) && entriesInRange[i]!=0)
 				entryNames.put(i, MainWindow.runObject[myRun].getSts().getEntryNames().get(i) + 
 						"::" + 
 						MainWindow.runObject[myRun].getSts().entryChares.get(i));
@@ -206,6 +208,19 @@ public class ChooseEntriesWindow extends JFrame
 
 		p.add(topPanel, BorderLayout.NORTH);
 		p.add(scroller, BorderLayout.CENTER);
+
+		// Color choices take effect as they are made; this just dismisses
+		// the window, which otherwise has no obvious way to be closed.
+		JButton done = new JButton("Done");
+		done.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				dispose();
+			}
+		});
+		JPanel donePanel = new JPanel();
+		donePanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
+		donePanel.add(done);
+		p.add(donePanel, BorderLayout.SOUTH);
 
 		this.setContentPane(p);
 

--- a/src/projections/gui/ScalePanel.java
+++ b/src/projections/gui/ScalePanel.java
@@ -11,12 +11,15 @@ package projections.gui;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Panel;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 public class ScalePanel extends Panel
@@ -196,8 +199,15 @@ public class ScalePanel extends Panel
 		}
 	}
 	
+	/** Turns a horizontal panel coordinate into text for the tick ruler.
+	 *  Only the panel knows what its coordinates mean, so it supplies this. */
+	public static interface AxisLabeler {
+		public String label(double panelCoordinate);
+	}
+
 	private Axis hor,ver;
 	private Child child;
+	private AxisLabeler horLabeler; //null: draw tick marks without labels
 	private int lC,rC,tC,bC; //The current child clip region
 	
 	//************ Mouse actions ********
@@ -281,9 +291,17 @@ public class ScalePanel extends Panel
 		
 		int tickSize=8;//Max. tick size; inset along bot & right edges
 		int upSet=2;//Inset along top & left edges
-		
+
+		//Tick labels, if any, take a text line below the horizontal ruler
+		FontMetrics fm=null;
+		int labelSize=0;
+		if (horLabeler!=null) {
+			fm=g.getFontMetrics();
+			labelSize=fm.getHeight();
+		}
+
 		//This is the clip region
-		lC=upSet; rC=w-tickSize; tC=upSet; bC=h-tickSize;
+		lC=upSet; rC=w-tickSize; tC=upSet; bC=h-tickSize-labelSize;
 		hor.setScreenSize(rC-lC); ver.setScreenSize(bC-tC);
 		
 		g.setColor(Color.black); //Erase old image
@@ -296,13 +314,15 @@ public class ScalePanel extends Panel
 		g.drawRect(lC-1,tC-1,rC-lC+1,bC-tC+1);
 		
 		float []ticks; //Array of (pixel pos, length fraction, label) pairs
-		ticks=hor.getTicks(0,w-tickSize-upSet);
-		for (int t=0;t<ticks.length/3;t++) { //Horizontal tick marks
-			int x=lC+(int)ticks[t*3+0];
-			int len=(int)((tickSize-2)*ticks[t*3+1]);
-			g.drawLine(x,h-tickSize,x,h-tickSize+len);
+		float []horTicks=hor.getTicks(0,rC-lC);
+		for (int t=0;t<horTicks.length/3;t++) { //Horizontal tick marks
+			int x=lC+(int)horTicks[t*3+0];
+			int len=(int)((tickSize-2)*horTicks[t*3+1]);
+			g.drawLine(x,bC,x,bC+len);
 		}
-		ticks=ver.getTicks(0,h-tickSize-upSet);
+		if (fm!=null)
+			drawHorizontalLabels(g,fm,horTicks,w,bC+tickSize+fm.getAscent());
+		ticks=ver.getTicks(0,bC-tC);
 		for (int t=0;t<ticks.length/3;t++) { //Vertical tick marks
 			int y=tC+(int)ticks[t*3+0];
 			int len=(int)((tickSize-2)*ticks[t*3+1]);
@@ -317,6 +337,52 @@ public class ScalePanel extends Panel
 		child.paint(new Child.RepaintRequest(g,rC-lC,bC-tC,hor,ver));
 		drawZoomCenter(g);
 	}
+	/** Label the tick marks, longest first so that the roundest numbers get
+	 *  the available room and shorter ticks fill whatever gaps are left.
+	 *  Labels that would collide are dropped rather than overprinted, so
+	 *  zooming in reveals more of them. */
+	private void drawHorizontalLabels(final Graphics g,FontMetrics fm,
+			final float[] ticks,int w,int baseline)
+	{
+		int nTicks=ticks.length/3;
+		Integer order[]=new Integer[nTicks];
+		for (int t=0;t<nTicks;t++)
+			order[t]=t;
+		Arrays.sort(order,new Comparator<Integer>() {
+			public int compare(Integer a,Integer b) {
+				return Float.compare(ticks[b*3+1],ticks[a*3+1]);
+			}
+		});
+
+		boolean taken[]=new boolean[w+1]; //pixel columns already spoken for
+		g.setColor(Color.lightGray);
+		for (int t=0;t<nTicks;t++) {
+			int tick=order[t];
+			String label=horLabeler.label(ticks[tick*3+2]);
+			int width=fm.stringWidth(label);
+			int left=lC+(int)ticks[tick*3+0]-width/2; //centered under the tick
+			if (left<lC) left=lC;
+			if (left+width>w) left=w-width;
+			if (left<0) continue; //label wider than the window
+			int from=Math.max(0,left-4), to=Math.min(w,left+width+4);
+			boolean room=true;
+			for (int x=from;x<=to && room;x++)
+				room=!taken[x];
+			if (!room) continue;
+			g.drawString(label,left,baseline);
+			for (int x=from;x<=to;x++)
+				taken[x]=true;
+		}
+		g.setColor(Color.gray);
+	}
+
+	/** Supply a labeler to get timestamps (or whatever the panel coordinates
+	 *  mean) written under the horizontal tick marks. */
+	public void setHorizontalAxisLabeler(AxisLabeler labeler) {
+		horLabeler=labeler;
+		repaint();
+	}
+
 	//Set the initial sizes
 	public void setScales(double hVal,double vVal)
 	{


### PR DESCRIPTION
Follow-on to #159, in the same lightly-exercised summary-detail paths, this time in the Overview (Small Time Line) tool. What sent me looking was a flood of `NullPointerException`s from picking entry colors; the display underneath turned out to be wrong in three further ways.

## Overview on summary-detail traces

- **Utilization was indexed by absolute PE number.** The panel indexes its rows by position in the selected PE list, but the data came from `getSumDetailData_PE_interval()`, which is allocated over every PE in the run. Any PE subset drew the wrong rows, and rows for unselected PEs were zeros. It now uses `getSystemUsageData()`, which is already indexed by selected PE, relative to the loaded range, and converted to percent.
- **Idle was indexed by absolute PE *and* absolute `.sum` interval** but read with a range-relative index, so any range not starting at interval 0 reported idle from the wrong point in time. Idle is now rebuilt per selected PE, mapping `.sumd` intervals to `.sum` intervals by time since the two files can be binned differently, and capped at what the entry methods leave free — the same reconciliation #159 gave Time Profile and Usage Profile.
- **The percent conversion stopped one interval short**, leaving the last interval as raw microseconds (~1000 on a 1 ms bin) fed to a 0-255 color map. That is the source of the `Warning: Invalid value ... being applied to the color map` lines.
- **"Color By: Entry Method" was never offered**, though `.sumd` files carry per-entry-method data. `IntervalData` now records the dominant entry method per (PE, interval) while it expands the RLE data, and the mode is available. Intervals with no recorded entry method time, or that the `.sum` file says were mostly idle, draw as idle.
- **The NPE:** the "Choose Entry Method Colors" button was created unconditionally while the radio button `colorsHaveChanged()` calls `isSelected()` on was created only for `.log` traces.

## Color chooser

The chooser now gets an `EntryMethodVisibility` filter from Overview, so it lists only the entry methods actually drawn instead of every one in the run (411 on my trace), reusing the mechanism #157 added for Time Profile. Idle and Overhead are left out, because Overview draws them white and black regardless of the palette — picking colors for them did nothing. Note this also removes those two rows for `.log` traces, where they were previously listed but equally inert.

It also gained a **Done** button. The window had no obvious way to be dismissed; colors still take effect as they are picked. This is in the shared `ChooseEntriesWindow`, so Timeline, Histogram, Time Profile and Usage Profile get it too — those keep their Idle/Overhead rows, which is correct since they really do draw those colors. And `ChooseEntriesWindow` now asks for the entry list once instead of on every row, because some tools answer that question by scanning their whole display.

## Time axis labels

Overview's bottom ruler already drew tick marks that tracked pan and zoom, and `getTicks()` already returned each tick's value — nothing drew it as text. `ScalePanel` gained an `AxisLabeler` hook and now writes timestamps under the ticks, placed longest-tick-first with collision avoidance so the roundest numbers get the room and zooming in reveals more labels. `ScalePanel` is used only by this tool.

## Testing

Manually verified by @lvkale on a 4-PE and a 1920-PE summary-detail trace (full range, PE subsets, sub-ranges, both color modes, axis labels) and a 120-PE `.log` trace, which ran clean; the Done button was checked in Timeline, Histogram, Time Profile and Usage Profile. Each commit builds on its own. `make test` passes.

Known limitation, filed separately as #160: Overview's per-PE-per-interval arrays are ~1.5 GB on the 1920-PE trace inside the launcher's 5 GB heap, so this will not scale far past that PE count. The issue lists three reclaims worth ~950 MB with no behavior change.